### PR TITLE
cli --ini param is now optional The default values of the settings are now loaded if the ini option is invalid of not specified

### DIFF
--- a/Holovibes/sources/cli.cc
+++ b/Holovibes/sources/cli.cc
@@ -158,16 +158,18 @@ int start_cli(holovibes::Holovibes& holovibes, const holovibes::OptionsDescripto
     }
 
     auto& cd = holovibes.get_cd();
-    std::string ini_path;
-    if (!opts.ini_path)
-    {
-        ini_path = GLOBAL_INI_PATH;
-        LOG_INFO << "No ini configuration file found, using " << ini_path;
-    }
-    else
-        ini_path = opts.ini_path.value();
 
-    holovibes::ini::load_ini(cd, ini_path);
+    if (opts.ini_path)
+    {
+        try
+        {
+            holovibes::ini::load_ini(cd, opts.ini_path.value());
+        }
+        catch (std::exception&)
+        {
+            LOG_WARN << "Configuration file not found, initialization with default values.";
+        }
+    }
 
     auto input_frame_file = open_input_file(holovibes, opts);
     size_t input_nb_frames = input_frame_file->get_total_nb_frames();

--- a/tests/test_holo_files.py
+++ b/tests/test_holo_files.py
@@ -33,11 +33,13 @@ def read_holo(path: str) -> Tuple[bytes, bytes, bytes]:
     return data
 
 
-def generate_holo_from(input: str, output: str, config: str) -> time.time:
+def generate_holo_from(input: str, output: str, config: str = None) -> time.time:
     t1 = time.time()
 
     # Run holovibes on file
     cmd = [HOLOVIBES_BIN, "-i", input, "-o", output]
+    if config:
+        cmd += ['--ini', config]
 
     sub = subprocess.run(cmd, stderr=subprocess.PIPE)
     assert sub.returncode == 0, sub.stderr.decode('utf-8')
@@ -86,8 +88,10 @@ def test_holo(folder: str):
             "Did not find the ref.holo file in folder {}".format(folder))
 
     if not os.path.isfile(config):
-        pytest.skip(
-            "Did not find the Holovibes.ini file in folder {}".format(folder))
+        config = None
+
+    if os.path.isfile(output):
+        os.remove(output)
 
     generate_holo_from(input, output, config)
     out = read_holo(output)


### PR DESCRIPTION
The default values of the settings are now loaded if the ini option is
invalid of not specified
Fixes #93