### PR TITLE
fix(ini_path)

### DIFF
--- a/Holovibes/includes/ini_config.hh
+++ b/Holovibes/includes/ini_config.hh
@@ -16,7 +16,7 @@ namespace holovibes
 namespace ini
 {
 static std::string global_ini_path = "";
-std::string& get_global_ini_path();
+std::string get_global_ini_path();
 
 void load_ini(ComputeDescriptor& cd, const std::string& ini_path);
 void load_ini(const boost::property_tree::ptree& ptree, ComputeDescriptor& cd);

--- a/Holovibes/sources/gui/windows/MainWindow.cc
+++ b/Holovibes/sources/gui/windows/MainWindow.cc
@@ -556,7 +556,6 @@ void MainWindow::notify_error(std::exception& e)
         }
 
         auto lambda = [this, accu = (dynamic_cast<AccumulationException*>(err_ptr) != nullptr)] {
-
             if (accu)
             {
                 cd_.img_acc_slice_xy_enabled = false;
@@ -655,7 +654,7 @@ void MainWindow::configure_holovibes() { open_file(::holovibes::ini::get_global_
 void MainWindow::write_ini()
 {
     // Saves the current state of holovibes in holovibes.ini located in Holovibes.exe directory
-    save_ini(GLOBAL_INI_PATH);
+    save_ini(holovibes::ini::get_global_ini_path());
     notify();
 }
 
@@ -1100,7 +1099,6 @@ void MainWindow::set_holographic_mode()
     {
 
         LOG_ERROR << "cannot set holographic mode: " << e.what();
-
     }
 }
 

--- a/Holovibes/sources/ini_config.cc
+++ b/Holovibes/sources/ini_config.cc
@@ -14,7 +14,7 @@ std::string get_appdata_holovibes_folder()
     return holovibes_folder;
 }
 
-std::string& get_global_ini_path()
+std::string get_global_ini_path()
 {
     if (global_ini_path.compare("") == 0)
     {


### PR DESCRIPTION
The GLOBAL_INI_PATH var has been changed in a previous commit.
However, a leftover reference to it was left in the class MainWindow.
This fixes that problem by using the new access method.