### PR TITLE
fix(aux_windows): fixed a crash with auxiliary windows

### DIFF
--- a/Holovibes/sources/API.cc
+++ b/Holovibes/sources/API.cc
@@ -84,9 +84,12 @@ void close_windows()
 
     UserInterfaceDescriptor::instance().sliceXZ.reset(nullptr);
     UserInterfaceDescriptor::instance().sliceYZ.reset(nullptr);
-    UserInterfaceDescriptor::instance().lens_window.reset(nullptr);
     UserInterfaceDescriptor::instance().filter2d_window.reset(nullptr);
-    UserInterfaceDescriptor::instance().raw_window.reset(nullptr);
+
+    if (UserInterfaceDescriptor::instance().lens_window)
+        set_lens_view(false, 0);
+    if (UserInterfaceDescriptor::instance().raw_window)
+        set_raw_view(false, 0);
 
     UserInterfaceDescriptor::instance().plot_window_.reset(nullptr);
 }

--- a/Holovibes/sources/gui/windows/RawWindow.cc
+++ b/Holovibes/sources/gui/windows/RawWindow.cc
@@ -32,10 +32,12 @@ RawWindow::RawWindow(QPoint p, QSize s, DisplayQueue* q, KindOfView k)
 
 RawWindow::~RawWindow()
 {
-    // The following line causes a crash in debug mode but prevent
-    // memory leaks in release.
+    // For unknown reasons, this causes a crash in debug and prevents memory leaks in release.
+    // It is therefore removed when using the debug mode
+#ifdef NDEBUG
     if (cuResource)
         cudaGraphicsUnregisterResource(cuResource);
+#endif
 }
 
 void RawWindow::initShaders()


### PR DESCRIPTION
A CUDA function that prevents leaks also caused problems in debug mode.
Now, the debug mode will leak more but at least it won't crash as much.
Close #178 