### PR TITLE
merge(fix_3d_cuts_ena_disa): fix 3d cut disabling crash

### DIFF
--- a/Holovibes/includes/API.hxx
+++ b/Holovibes/includes/API.hxx
@@ -189,6 +189,7 @@ inline bool get_filter2d_enabled() { return get_cd().get_filter2d_enabled(); }
 inline bool get_filter2d_view_enabled() { return get_cd().get_filter2d_view_enabled(); }
 
 inline bool get_3d_cuts_view_enabled() { return get_cd().get_3d_cuts_view_enabled(); }
+inline void set_3d_cuts_view_enabled(bool value) { get_cd().set_3d_cuts_view_enabled(value); }
 
 inline bool get_lens_view_enabled() { return get_cd().get_lens_view_enabled(); }
 

--- a/Holovibes/sources/API.cc
+++ b/Holovibes/sources/API.cc
@@ -381,7 +381,6 @@ void update_time_transformation_stride(std::function<void()> callback, const uin
 
 bool set_3d_cuts_view(uint time_transformation_size)
 {
-    // if checked
     try
     {
         get_compute_pipe()->create_stft_slice_queue();
@@ -416,7 +415,7 @@ bool set_3d_cuts_view(uint time_transformation_size)
         UserInterfaceDescriptor::instance().sliceYZ->setFlip(get_cd().get_yz_flip_enabled());
 
         UserInterfaceDescriptor::instance().mainDisplay->getOverlayManager().create_overlay<gui::Cross>();
-        get_cd().set_3d_cuts_view_enabled(true);
+        set_3d_cuts_view_enabled(true);
         auto holo = dynamic_cast<gui::HoloWindow*>(UserInterfaceDescriptor::instance().mainDisplay.get());
         if (holo)
             holo->update_slice_transforms();
@@ -454,8 +453,6 @@ void cancel_time_transformation_cuts(std::function<void()> callback)
     {
         LOG_ERROR << e.what();
     }
-
-    get_cd().set_3d_cuts_view_enabled(false);
 }
 
 #pragma endregion

--- a/Holovibes/sources/core/pipe.cc
+++ b/Holovibes/sources/core/pipe.cc
@@ -420,13 +420,11 @@ void Pipe::refresh()
 
 void Pipe::insert_wait_frames()
 {
-    fn_compute_vect_.push_back(
-        [&]()
-        {
-            // Wait while the input queue is enough filled
-            while (gpu_input_queue_.is_empty())
-                continue;
-        });
+    fn_compute_vect_.push_back([&]() {
+        // Wait while the input queue is enough filled
+        while (gpu_input_queue_.is_empty())
+            continue;
+    });
 }
 
 void Pipe::insert_reset_batch_index()
@@ -436,24 +434,20 @@ void Pipe::insert_reset_batch_index()
 
 void Pipe::insert_transfer_for_time_transformation()
 {
-    fn_compute_vect_.push_back(
-        [&]()
-        {
-            time_transformation_env_.gpu_time_transformation_queue->enqueue_multiple(
-                buffers_.gpu_spatial_transformation_buffer.get(),
-                cd_.batch_size,
-                stream_);
-        });
+    fn_compute_vect_.push_back([&]() {
+        time_transformation_env_.gpu_time_transformation_queue->enqueue_multiple(
+            buffers_.gpu_spatial_transformation_buffer.get(),
+            cd_.batch_size,
+            stream_);
+    });
 }
 
 void Pipe::update_batch_index()
 {
-    fn_compute_vect_.push_back(
-        [&]()
-        {
-            batch_env_.batch_index += cd_.batch_size;
-            CHECK(batch_env_.batch_index <= cd_.time_transformation_stride);
-        });
+    fn_compute_vect_.push_back([&]() {
+        batch_env_.batch_index += cd_.batch_size;
+        CHECK(batch_env_.batch_index <= cd_.time_transformation_stride);
+    });
 }
 
 void Pipe::safe_enqueue_output(Queue& output_queue, unsigned short* frame, const std::string& error)
@@ -464,85 +458,79 @@ void Pipe::safe_enqueue_output(Queue& output_queue, unsigned short* frame, const
 
 void Pipe::insert_dequeue_input()
 {
-    fn_compute_vect_.push_back(
-        [&]()
-        {
-            *processed_output_fps_ += cd_.batch_size;
+    fn_compute_vect_.push_back([&]() {
+        *processed_output_fps_ += cd_.batch_size;
 
-            // FIXME: It seems this enqueue is useless because the RawWindow use
-            // the gpu input queue for display
-            /* safe_enqueue_output(
-            **    gpu_output_queue_,
-            **    static_cast<unsigned short*>(gpu_input_queue_.get_start()),
-            **    "Can't enqueue the input frame in gpu_output_queue");
-            */
+        // FIXME: It seems this enqueue is useless because the RawWindow use
+        // the gpu input queue for display
+        /* safe_enqueue_output(
+        **    gpu_output_queue_,
+        **    static_cast<unsigned short*>(gpu_input_queue_.get_start()),
+        **    "Can't enqueue the input frame in gpu_output_queue");
+        */
 
-            // Dequeue a batch
-            gpu_input_queue_.dequeue();
-        });
+        // Dequeue a batch
+        gpu_input_queue_.dequeue();
+    });
 }
 
 void Pipe::insert_output_enqueue_hologram_mode()
 {
-    fn_compute_vect_.conditional_push_back(
-        [&]()
+    fn_compute_vect_.conditional_push_back([&]() {
+        (*processed_output_fps_)++;
+
+        safe_enqueue_output(gpu_output_queue_,
+                            buffers_.gpu_output_frame.get(),
+                            "Can't enqueue the output frame in gpu_output_queue");
+
+        // Always enqueue the cuts if enabled
+        if (cd_.time_transformation_cuts_enabled)
         {
-            (*processed_output_fps_)++;
+            safe_enqueue_output(*time_transformation_env_.gpu_output_queue_xz.get(),
+                                buffers_.gpu_output_frame_xz.get(),
+                                "Can't enqueue the output xz frame in output xz queue");
 
-            safe_enqueue_output(gpu_output_queue_,
-                                buffers_.gpu_output_frame.get(),
-                                "Can't enqueue the output frame in gpu_output_queue");
+            safe_enqueue_output(*time_transformation_env_.gpu_output_queue_yz.get(),
+                                buffers_.gpu_output_frame_yz.get(),
+                                "Can't enqueue the output yz frame in output yz queue");
+        }
 
-            // Always enqueue the cuts if enabled
-            if (cd_.time_transformation_cuts_enabled)
-            {
-                safe_enqueue_output(*time_transformation_env_.gpu_output_queue_xz.get(),
-                                    buffers_.gpu_output_frame_xz.get(),
-                                    "Can't enqueue the output xz frame in output xz queue");
-
-                safe_enqueue_output(*time_transformation_env_.gpu_output_queue_yz.get(),
-                                    buffers_.gpu_output_frame_yz.get(),
-                                    "Can't enqueue the output yz frame in output yz queue");
-            }
-
-            if (cd_.filter2d_view_enabled)
-            {
-                safe_enqueue_output(*gpu_filter2d_view_queue_.get(),
-                                    buffers_.gpu_filter2d_frame.get(),
-                                    "Can't enqueue the output frame in "
-                                    "gpu_filter2d_view_queue");
-            }
-        });
+        if (cd_.filter2d_view_enabled)
+        {
+            safe_enqueue_output(*gpu_filter2d_view_queue_.get(),
+                                buffers_.gpu_filter2d_frame.get(),
+                                "Can't enqueue the output frame in "
+                                "gpu_filter2d_view_queue");
+        }
+    });
 }
 
 void Pipe::insert_filter2d_view()
 {
     if (cd_.filter2d_enabled == true && cd_.filter2d_view_enabled == true)
     {
-        fn_compute_vect_.conditional_push_back(
-            [&]()
-            {
-                float_to_complex(buffers_.gpu_complex_filter2d_frame.get(),
-                                 buffers_.gpu_postprocess_frame.get(),
-                                 buffers_.gpu_postprocess_frame_size,
-                                 stream_);
+        fn_compute_vect_.conditional_push_back([&]() {
+            float_to_complex(buffers_.gpu_complex_filter2d_frame.get(),
+                             buffers_.gpu_postprocess_frame.get(),
+                             buffers_.gpu_postprocess_frame_size,
+                             stream_);
 
-                int width = gpu_output_queue_.get_fd().width;
-                int height = gpu_output_queue_.get_fd().height;
-                CufftHandle handle{width, height, CUFFT_C2C};
+            int width = gpu_output_queue_.get_fd().width;
+            int height = gpu_output_queue_.get_fd().height;
+            CufftHandle handle{width, height, CUFFT_C2C};
 
-                cufftSafeCall(cufftExecC2C(handle,
-                                           buffers_.gpu_complex_filter2d_frame.get(),
-                                           buffers_.gpu_complex_filter2d_frame.get(),
-                                           CUFFT_FORWARD));
-                shift_corners(buffers_.gpu_complex_filter2d_frame.get(), 1, width, height, stream_);
-                complex_to_modulus(buffers_.gpu_float_filter2d_frame.get(),
-                                   buffers_.gpu_complex_filter2d_frame.get(),
-                                   0,
-                                   0,
-                                   buffers_.gpu_postprocess_frame_size,
-                                   stream_);
-            });
+            cufftSafeCall(cufftExecC2C(handle,
+                                       buffers_.gpu_complex_filter2d_frame.get(),
+                                       buffers_.gpu_complex_filter2d_frame.get(),
+                                       CUFFT_FORWARD));
+            shift_corners(buffers_.gpu_complex_filter2d_frame.get(), 1, width, height, stream_);
+            complex_to_modulus(buffers_.gpu_float_filter2d_frame.get(),
+                               buffers_.gpu_complex_filter2d_frame.get(),
+                               0,
+                               0,
+                               buffers_.gpu_postprocess_frame_size,
+                               stream_);
+        });
     }
 }
 
@@ -553,13 +541,11 @@ void Pipe::insert_raw_view()
         // FIXME: Copy multiple copies a batch of frames
         // The view use get last image which will always the
         // last image of the batch.
-        fn_compute_vect_.push_back(
-            [&]()
-            {
-                // Copy a batch of frame from the input queue to the raw view
-                // queue
-                gpu_input_queue_.copy_multiple(*get_raw_view_queue());
-            });
+        fn_compute_vect_.push_back([&]() {
+            // Copy a batch of frame from the input queue to the raw view
+            // queue
+            gpu_input_queue_.copy_multiple(*get_raw_view_queue());
+        });
     }
 }
 
@@ -567,9 +553,9 @@ void Pipe::insert_raw_record()
 {
     if (cd_.frame_record_enabled && frame_record_env_.record_mode_ == RecordMode::RAW)
     {
-        fn_compute_vect_.push_back(
-            [&]()
-            { gpu_input_queue_.copy_multiple(*frame_record_env_.gpu_frame_record_queue_, cd_.batch_size.load()); });
+        fn_compute_vect_.push_back([&]() {
+            gpu_input_queue_.copy_multiple(*frame_record_env_.gpu_frame_record_queue_, cd_.batch_size.load());
+        });
     }
 }
 
@@ -577,15 +563,12 @@ void Pipe::insert_hologram_record()
 {
     if (cd_.frame_record_enabled && frame_record_env_.record_mode_ == RecordMode::HOLOGRAM)
     {
-        fn_compute_vect_.conditional_push_back(
-            [&]()
-            {
-                if (gpu_output_queue_.get_fd().depth == 6) // Complex mode
-                    frame_record_env_.gpu_frame_record_queue_->enqueue_from_48bit(buffers_.gpu_output_frame.get(),
-                                                                                  stream_);
-                else
-                    frame_record_env_.gpu_frame_record_queue_->enqueue(buffers_.gpu_output_frame.get(), stream_);
-            });
+        fn_compute_vect_.conditional_push_back([&]() {
+            if (gpu_output_queue_.get_fd().depth == 6) // Complex mode
+                frame_record_env_.gpu_frame_record_queue_->enqueue_from_48bit(buffers_.gpu_output_frame.get(), stream_);
+            else
+                frame_record_env_.gpu_frame_record_queue_->enqueue(buffers_.gpu_output_frame.get(), stream_);
+        });
     }
 }
 
@@ -595,15 +578,15 @@ void Pipe::insert_cuts_record()
     {
         if (frame_record_env_.record_mode_ == RecordMode::CUTS_XZ)
         {
-            fn_compute_vect_.push_back(
-                [&]()
-                { frame_record_env_.gpu_frame_record_queue_->enqueue(buffers_.gpu_output_frame_xz.get(), stream_); });
+            fn_compute_vect_.push_back([&]() {
+                frame_record_env_.gpu_frame_record_queue_->enqueue(buffers_.gpu_output_frame_xz.get(), stream_);
+            });
         }
         else if (frame_record_env_.record_mode_ == RecordMode::CUTS_YZ)
         {
-            fn_compute_vect_.push_back(
-                [&]()
-                { frame_record_env_.gpu_frame_record_queue_->enqueue(buffers_.gpu_output_frame_yz.get(), stream_); });
+            fn_compute_vect_.push_back([&]() {
+                frame_record_env_.gpu_frame_record_queue_->enqueue(buffers_.gpu_output_frame_yz.get(), stream_);
+            });
         }
     }
 }

--- a/Holovibes/sources/gui/windows/panels/export_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/export_panel.cc
@@ -272,8 +272,9 @@ void ExportPanel::start_record()
 
     ui_->InfoPanel->set_visible_record_progress(true);
 
-    auto callback = [record_mode = UserInterfaceDescriptor::instance().record_mode_, this]()
-    { parent_->synchronize_thread([=]() { record_finished(record_mode); }); };
+    auto callback = [record_mode = UserInterfaceDescriptor::instance().record_mode_, this]() {
+        parent_->synchronize_thread([=]() { record_finished(record_mode); });
+    };
 
     api::start_record(batch_enabled, nb_frames_to_record, output_path, batch_input_path, callback);
 }

--- a/Holovibes/sources/gui/windows/panels/view_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/view_panel.cc
@@ -210,7 +210,7 @@ void ViewPanel::cancel_time_transformation_cuts()
     if (auto pipe = dynamic_cast<Pipe*>(Holovibes::instance().get_compute_pipe().get()))
     {
         callback = ([=]() {
-            api::get_cd().set_3d_cuts_view_enabled(false);
+            api::set_3d_cuts_view_enabled(false);
             pipe->delete_stft_slice_queue();
 
             ui_->TimeTransformationCutsCheckBox->setChecked(false);


### PR DESCRIPTION
When disabling 3D cuts view, the software was crashing.
It was due to a bad function call (due to a renaming) in commit with sha: daa0c4d0a5716938a09aa1c8c71d7468cab8e725