### PR TITLE
fix(3Dcuts): fixed a crash when stopping import with 3Dcuts enabled

### DIFF
--- a/Holovibes/includes/core/holovibes.hh
+++ b/Holovibes/includes/core/holovibes.hh
@@ -226,6 +226,7 @@ class Holovibes
 
     void stop_compute();
 
+    // Always close the 3D cuts before calling this function
     void stop_all_worker_controller();
 
     void start_cli_record_and_compute(const std::string& path,

--- a/Holovibes/sources/API.cc
+++ b/Holovibes/sources/API.cc
@@ -1213,10 +1213,11 @@ void record_finished() { UserInterfaceDescriptor::instance().is_recording_ = fal
 
 void import_stop()
 {
+    close_windows();
+    close_critical_compute();
+
     Holovibes::instance().stop_all_worker_controller();
     Holovibes::instance().start_information_display();
-
-    close_critical_compute();
 
     UserInterfaceDescriptor::instance().import_type_ = ImportType::None;
 

--- a/Holovibes/sources/gui/windows/panels/import_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/import_panel.cc
@@ -127,13 +127,12 @@ void ImportPanel::import_stop()
     if (UserInterfaceDescriptor::instance().import_type_ == ImportType::None)
         return;
 
-    api::close_windows();
-    // cancel_time_transformation_cuts();
-
     api::import_stop();
+
     // FIXME: import_stop() and camera_none() call same methods
     // FIXME: camera_none() weird call because we are dealing with imported file
     parent_->camera_none();
+
     parent_->synchronize_thread([&]() { ui_->FileReaderProgressBar->hide(); });
     parent_->notify();
 }


### PR DESCRIPTION
The stop_all_worker_controller function was called before closing the 3D cuts.
This causes a crash, and the cuts should always be closed before calling this function.
Close #193 