### PR TITLE
Fix 10.5.2 record gui

### DIFF
--- a/Holovibes/sources/thread/frame_record_worker.cc
+++ b/Holovibes/sources/thread/frame_record_worker.cc
@@ -36,7 +36,6 @@ void FrameRecordWorker::run()
 
     auto fast_update_progress_entry = GSH::fast_updates_map<ProgressType>.create_entry(ProgressType::FRAME_RECORD);
     std::atomic<uint>& nb_frames_recorded = fast_update_progress_entry->first;
-
     std::atomic<uint>& nb_frames_to_record = fast_update_progress_entry->second;
 
     nb_frames_recorded = 0;


### PR DESCRIPTION
During a refacto of the file read worker, a logical error was made, flipping a condition the other way.
This fixes that, and visually fixes the number of frames to record.