### PR TITLE
fix(cli): split file info and file compute settings import

### DIFF
--- a/Holovibes/includes/io_files/input_cine_file.hh
+++ b/Holovibes/includes/io_files/input_cine_file.hh
@@ -31,6 +31,12 @@ class InputCineFile : public InputFrameFile, public CineFile
      */
     void import_compute_settings(ComputeDescriptor& cd) const override;
 
+    /*! \brief Update ComputeDescriptor with the settings present in the file
+     *
+     *  \param cd The ComputeDescriptor to update
+     */
+    void import_info(ComputeDescriptor& cd) const override;
+
     /*! \brief Set the pointer in the file to the frame requested
      *
      * This method is mandatory to read frames.

--- a/Holovibes/includes/io_files/input_frame_file.hh
+++ b/Holovibes/includes/io_files/input_frame_file.hh
@@ -26,6 +26,12 @@ class InputFrameFile : public FrameFile
      */
     virtual void import_compute_settings(ComputeDescriptor& cd) const = 0;
 
+    /*! \brief Update ComputeDescriptor with the info settings present in the file
+     *
+     * \param cd The ComputeDescriptor to update
+     */
+    virtual void import_info(ComputeDescriptor& cd) const = 0;
+
     /*! \brief Set the pointer in the file to the frame requested
      *
      * This method must be called before the first read_frames call

--- a/Holovibes/includes/io_files/input_holo_file.hh
+++ b/Holovibes/includes/io_files/input_holo_file.hh
@@ -33,6 +33,12 @@ class InputHoloFile : public InputFrameFile, public HoloFile
      */
     void import_compute_settings(ComputeDescriptor& cd) const override;
 
+    /*! \brief Update ComputeDescriptor with the settings present in the file
+     *
+     * \param cd The ComputeDescriptor to update
+     */
+    void import_info(ComputeDescriptor& cd) const override;
+
   private:
     // Give access to private members to the factory
     friend class InputFrameFileFactory;

--- a/Holovibes/sources/cli.cc
+++ b/Holovibes/sources/cli.cc
@@ -106,6 +106,9 @@ static bool set_parameters(holovibes::Holovibes& holovibes, const holovibes::Opt
     if (!opts.compute_settings_path)
         input_frame_file->import_compute_settings(holovibes::api::get_cd());
 
+    // Pixel size is set with info section of input file
+    input_frame_file->import_info(holovibes::api::get_cd());
+
     const camera::FrameDescriptor& fd = input_frame_file->get_frame_descriptor();
 
     if (!get_first_and_last_frame(opts, static_cast<uint>(input_frame_file->get_total_nb_frames()), cd))

--- a/Holovibes/sources/gui/windows/panels/import_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/import_panel.cc
@@ -107,6 +107,7 @@ void ImportPanel::import_file(const QString& filename)
         size_t nb_frames = input_file->get_total_nb_frames();
         UserInterfaceDescriptor::instance().file_fd_ = input_file->get_frame_descriptor();
         input_file->import_compute_settings(api::get_cd());
+        input_file->import_info(api::get_cd());
 
         // Don't need the input file anymore
         delete input_file;

--- a/Holovibes/sources/io_files/input_cine_file.cc
+++ b/Holovibes/sources/io_files/input_cine_file.cc
@@ -36,7 +36,9 @@ InputCineFile::InputCineFile(const std::string& file_path)
     packed_frame_size_ = bitmap_info_header_.bi_size_image;
 }
 
-void InputCineFile::import_compute_settings(holovibes::ComputeDescriptor& cd) const
+void InputCineFile::import_compute_settings(holovibes::ComputeDescriptor& cd) const {}
+
+void InputCineFile::import_info(holovibes::ComputeDescriptor& cd) const
 {
     cd.pixel_size = 1e6 / static_cast<float>(bitmap_info_header_.bi_x_pels_per_meter);
 }

--- a/Holovibes/sources/io_files/input_holo_file.cc
+++ b/Holovibes/sources/io_files/input_holo_file.cc
@@ -103,10 +103,6 @@ T get_value(const json& json, const std::string& key, const T& default_value)
 void import_holo_v4(holovibes::ComputeDescriptor& cd, const json& meta_data)
 {
     api::json_to_compute_settings(meta_data["compute settings"]);
-
-    const json& file_info_data = meta_data["info"];
-    cd.pixel_size = file_info_data["pixel size"]["x"];
-    cd.raw_bitshift = file_info_data["raw bitshift"];
 }
 
 void import_holo_v2_v3(holovibes::ComputeDescriptor& cd, const json& meta_data)
@@ -120,7 +116,6 @@ void import_holo_v2_v3(holovibes::ComputeDescriptor& cd, const json& meta_data)
     cd.time_transformation_size = get_value(meta_data, "#img", cd.time_transformation_size.load());
     cd.p.index = get_value(meta_data, "p", cd.p.index.load());
     cd.lambda = get_value(meta_data, "lambda", cd.lambda.load());
-    cd.pixel_size = get_value(meta_data, "pixel_size", cd.pixel_size.load());
     cd.zdistance = get_value(meta_data, "z", cd.zdistance.load());
     cd.xy.log_scale_slice_enabled = get_value(meta_data, "log_scale", cd.xy.log_scale_slice_enabled.load());
     cd.xy.contrast_min = get_value(meta_data, "contrast_min", cd.xy.contrast_min.load());
@@ -141,6 +136,22 @@ void InputHoloFile::import_compute_settings(holovibes::ComputeDescriptor& cd) co
         import_holo_v4(cd, meta_data_);
     else if (holo_file_header_.version < 4)
         import_holo_v2_v3(cd, meta_data_);
+    else
+        LOG_ERROR << "HOLO file version not supported!";
+}
+
+void InputHoloFile::import_info(holovibes::ComputeDescriptor& cd) const
+{
+    if (holo_file_header_.version == 4)
+    {
+        const json& file_info_data = meta_data_["info"];
+        cd.pixel_size = file_info_data["pixel size"]["x"];
+        cd.raw_bitshift = file_info_data["raw bitshift"];
+    }
+    else if (holo_file_header_.version < 4)
+    {
+        cd.pixel_size = get_value(meta_data_, "pixel_size", cd.pixel_size.load());
+    }
     else
         LOG_ERROR << "HOLO file version not supported!";
 }


### PR DESCRIPTION
Because CLI does not import HOLO/CINE settings. 
The pixel size was not set. As a consequence, cine output in CLI was bad.

We split import_compute_settings with import_info.