### PR TITLE
fix(record): fixed a crash when stopping the record

### DIFF
--- a/Holovibes/sources/thread/frame_record_worker.cc
+++ b/Holovibes/sources/thread/frame_record_worker.cc
@@ -84,6 +84,10 @@ void FrameRecordWorker::run()
             }
 
             wait_for_frames(record_queue);
+
+            // While wait_for_frames() is running, a stop might be requested and the queue reset.
+            // To avoid problems with dequeuing while it's empty, we check right after wait_for_frame
+            // and stop recording if needed.
             if (stop_requested_)
                 break;
 


### PR DESCRIPTION
Wait_for_frames might request the end of the record, and the queue is reinitialized. However, a dequeue was used right after that without any checks, which caused a check to fail when pressing the stop button.