### PR TITLE
feat(info): Added dynamic resize if info panel is too small

### DIFF
--- a/Holovibes/includes/gui/windows/panels/info_panel.hh
+++ b/Holovibes/includes/gui/windows/panels/info_panel.hh
@@ -35,5 +35,9 @@ class InfoPanel : public Panel
 
     /*! \brief Show or hide the record progress */
     void set_visible_record_progress(bool visible);
+
+  private:
+    int height_ = 0;
+    int resize_again_ = 0;
 };
 } // namespace holovibes::gui

--- a/Holovibes/sources/gui/windows/panels/info_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/info_panel.cc
@@ -52,7 +52,24 @@ void InfoPanel::load_gui(const boost::property_tree::ptree& ptree)
 
 void InfoPanel::save_gui(boost::property_tree::ptree& ptree) { ptree.put<bool>("window.info_hidden", isHidden()); }
 
-void InfoPanel::set_text(const char* text) { ui_->InfoTextEdit->setText(text); }
+void InfoPanel::set_text(const char* text)
+{
+    QTextEdit* text_edit = ui_->InfoTextEdit;
+
+    text_edit->setText(text);
+
+    // For some reason, the GUI needs multiple updates to return to its base layout
+    if (resize_again_-- > 0)
+        parent_->adjustSize();
+
+    if (text_edit->document()->size().height() != height_)
+    {
+        height_ = text_edit->document()->size().height();
+        text_edit->setMinimumSize(0, height_);
+        parent_->adjustSize();
+        resize_again_ = 3;
+    }
+}
 
 void InfoPanel::set_visible_file_reader_progress(bool visible)
 {


### PR DESCRIPTION
When the info panel is too small to handle every info, increase its size.
If the info panel can handle the text with its base size, it returns to the normal layout.
The text overload is especially apparent when recording.