### PR TITLE
fix(icon): Fixed icons not being shown after the installer

### DIFF
--- a/Holovibes/Holovibes.qrc
+++ b/Holovibes/Holovibes.qrc
@@ -1,6 +1,5 @@
 <!DOCTYPE RCC><RCC version="1.0">
 <qresource>
     <file>holovibes_logo.png</file>
-    <file>Holovibes.ico</file>
 </qresource>
 </RCC>

--- a/Holovibes/sources/gui/windows/AdvancedSettingsWindow.cc
+++ b/Holovibes/sources/gui/windows/AdvancedSettingsWindow.cc
@@ -10,7 +10,7 @@ AdvancedSettingsWindow::AdvancedSettingsWindow(QMainWindow* parent, AdvancedSett
 {
 
     ui.setupUi(this);
-    setWindowIcon(QIcon(":/Holovibes.ico"));
+    setWindowIcon(QIcon(":/holovibes_logo.png"));
     this->setAttribute(Qt::WA_DeleteOnClose);
     this->show();
 

--- a/Holovibes/sources/gui/windows/BasicOpenGLWindow.cc
+++ b/Holovibes/sources/gui/windows/BasicOpenGLWindow.cc
@@ -46,7 +46,7 @@ BasicOpenGLWindow::BasicOpenGLWindow(QPoint p, QSize s, DisplayQueue* q, KindOfV
     cudaSafeCall(cudaStreamCreateWithPriority(&cuStream, cudaStreamDefault, CUDA_STREAM_WINDOW_PRIORITY));
     resize(s);
     setFramePosition(p);
-    setIcon(QIcon(":/Holovibes.ico"));
+    setIcon(QIcon(":/holovibes_logo.png"));
     this->installEventFilter(this);
 }
 

--- a/Holovibes/sources/gui/windows/MainWindow.cc
+++ b/Holovibes/sources/gui/windows/MainWindow.cc
@@ -79,7 +79,7 @@ MainWindow::MainWindow(QWidget* parent)
             this,
             SLOT(synchronize_thread(std::function<void()>)));
 
-    setWindowIcon(QIcon(":/Holovibes.ico"));
+    setWindowIcon(QIcon(":/holovibes_logo.png"));
 
     ::holovibes::worker::InformationWorker::display_info_text_function_ = [=](const std::string& text)
     { synchronize_thread([=]() { ui_->InfoPanel->set_text(text.c_str()); }); };


### PR DESCRIPTION
The .ico format is not supported by QIcon on Windows without additional plugins.
This made icons not work on every release.
We had the same image but bigger and a png, so I used that and it works just fine.