### PR TITLE
fix(advanced-settings) close on save

### DIFF
--- a/Holovibes/sources/gui/windows/AdvancedSettingsWindow.cc
+++ b/Holovibes/sources/gui/windows/AdvancedSettingsWindow.cc
@@ -71,6 +71,7 @@ void AdvancedSettingsWindow::set_ui_values()
         specific_panel_->set_ui_values();
 
     UserInterfaceDescriptor::instance().has_been_updated = true;
+    this->close();
 }
 
 void AdvancedSettingsWindow::change_input_folder_path() { change_folder(ui.InputFolderPathLineEdit); }


### PR DESCRIPTION
Saving then closing the advanced setting window is not intuitive and cumbersome.
Now clicking on the save button save the advanced settings and close the advanced settings window.