### PR TITLE
Light UI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 13.0.0
+
+- New light UI added
+
 ### 12.11.1
 
 - Fix s711 camera

--- a/Holovibes/includes/batch_input_queue.hh
+++ b/Holovibes/includes/batch_input_queue.hh
@@ -155,7 +155,7 @@ class BatchInputQueue final : public DisplayQueue
 
     uint get_max_size() const { return max_size_; }
 
-    bool has_overridden() const { return has_overridden_; }
+    bool has_overwritten() const { return has_overwritten_; }
 
     void reset_override();
 
@@ -253,7 +253,7 @@ class BatchInputQueue final : public DisplayQueue
     /*! \brief End index is the index after the last batch */
     std::atomic<uint> end_index_{0};
     /*! \brief Number of batches. Batch size can only be changed by the consumer */
-    std::atomic<bool> has_overridden_{false};
+    std::atomic<bool> has_overwritten_{false};
 
     /*! \brief Counting how many frames have been enqueued in the current batch. */
     std::atomic<uint> curr_batch_counter_{0};

--- a/Holovibes/includes/gui/windows/MainWindow.hh
+++ b/Holovibes/includes/gui/windows/MainWindow.hh
@@ -79,9 +79,6 @@ class MainWindow : public QMainWindow, public Observer
     uint window_max_size = 768;
     uint auxiliary_window_max_size = 512;
 
-    ExportPanel* get_export_panel();
-    ImageRenderingPanel* get_image_rendering_panel();
-
   public slots:
     void on_notify();
     /*! \brief Give a function to execute to the main thread with a signal

--- a/Holovibes/includes/gui/windows/lightui.hh
+++ b/Holovibes/includes/gui/windows/lightui.hh
@@ -41,6 +41,9 @@ class LightUI : public QMainWindow
     void z_value_changed_spinBox(int z_distance);
     void z_value_changed_slider(int z_distance);
 
+  protected:
+    void closeEvent(QCloseEvent *event) override;
+  
   private:
     Ui::LightUI* ui_;
     MainWindow* main_window_;

--- a/Holovibes/includes/gui/windows/lightui.hh
+++ b/Holovibes/includes/gui/windows/lightui.hh
@@ -27,6 +27,7 @@ class LightUI : public QMainWindow
     void showEvent(QShowEvent* event) override;
     void actualise_record_output_file_ui(const QString& filename);
     void actualise_z_distance(const double z_distance);
+    void reset_start_button();
 
   public slots:
     /*! \brief Opens file explorer on the fly to let the user chose the output file he wants with extension

--- a/Holovibes/includes/gui/windows/lightui.hh
+++ b/Holovibes/includes/gui/windows/lightui.hh
@@ -19,10 +19,10 @@ class LightUI : public QMainWindow
     Q_OBJECT
 
   public:
-    explicit LightUI(QWidget* parent = nullptr,
-                     MainWindow* main_window = nullptr,
-                     ExportPanel* export_panel = nullptr,
-                     ImageRenderingPanel* image_rendering_panel = nullptr);
+    explicit LightUI(QWidget* parent,
+                     MainWindow* main_window,
+                     ExportPanel* export_panel,
+                     ImageRenderingPanel* image_rendering_panel);
     ~LightUI();
     void showEvent(QShowEvent* event) override;
     void actualise_record_output_file_ui(const QString& filename);

--- a/Holovibes/includes/gui/windows/lightui.hh
+++ b/Holovibes/includes/gui/windows/lightui.hh
@@ -37,7 +37,7 @@ class LightUI : public QMainWindow
 
     /*! \brief Start/Stops the record */
     void start_stop_recording(bool start);
-    void z_value_changed(double z_distance);
+    void z_value_changed(int z_distance);
 
   private:
     Ui::LightUI* ui_;

--- a/Holovibes/includes/gui/windows/lightui.hh
+++ b/Holovibes/includes/gui/windows/lightui.hh
@@ -37,7 +37,8 @@ class LightUI : public QMainWindow
 
     /*! \brief Start/Stops the record */
     void start_stop_recording(bool start);
-    void z_value_changed(int z_distance);
+    void z_value_changed_spinBox(int z_distance);
+    void z_value_changed_slider(int z_distance);
 
   private:
     Ui::LightUI* ui_;

--- a/Holovibes/includes/gui/windows/panels/export_panel.hh
+++ b/Holovibes/includes/gui/windows/panels/export_panel.hh
@@ -31,7 +31,7 @@ class ExportPanel : public Panel
     void set_record_frame_step(int step);
     int get_record_frame_step();
 
-    void set_light_ui(LightUI* light_ui);
+    void set_light_ui(std::shared_ptr<LightUI> light_ui);
 
   public slots:
     /*! \brief Opens file explorer on the fly to let the user chose the output file he wants with extension

--- a/Holovibes/includes/gui/windows/panels/image_rendering_panel.hh
+++ b/Holovibes/includes/gui/windows/panels/image_rendering_panel.hh
@@ -30,7 +30,7 @@ class ImageRenderingPanel : public Panel
     void load_gui(const json& j_us) override;
     void save_gui(json& j_us) override;
 
-    void set_light_ui(LightUI* light_ui);
+    void set_light_ui(std::shared_ptr<LightUI> light_ui);
 
     // std::unique_ptr<Filter2DWindow> filter2d_window = nullptr;
 

--- a/Holovibes/lightui.ui
+++ b/Holovibes/lightui.ui
@@ -44,13 +44,29 @@
       </item>
       <item>
        <widget class="QSlider" name="horizontalSlider">
+        <property name="maximum">
+         <number>1000</number>
+        </property>
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QDoubleSpinBox" name="ZDoubleSpinBox"/>
+       <widget class="QSpinBox" name="ZSpinBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>60</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
       </item>
      </layout>
     </item>
@@ -202,6 +218,6 @@
  </connections>
  <slots>
   <slot>start_stop_recording()</slot>
-  <slot>z_value_changed(double)</slot>
+  <slot>z_value_changed(int)</slot>
  </slots>
 </ui>

--- a/Holovibes/lightui.ui
+++ b/Holovibes/lightui.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>638</width>
+    <width>430</width>
     <height>155</height>
    </rect>
   </property>
@@ -25,7 +25,7 @@
   <widget class="QWidget" name="formLayoutWidget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <property name="sizeConstraint">
-     <enum>QLayout::SetNoConstraint</enum>
+     <enum>QLayout::SetMinAndMaxSize</enum>
     </property>
     <property name="leftMargin">
      <number>10</number>
@@ -38,14 +38,17 @@
       <item>
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Propagation distance (cm)</string>
+         <string>Propagation distance (mm)</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QSlider" name="horizontalSlider">
+       <widget class="QSlider" name="ZSlider">
         <property name="maximum">
          <number>1000</number>
+        </property>
+        <property name="pageStep">
+         <number>1</number>
         </property>
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -65,6 +68,9 @@
           <width>60</width>
           <height>0</height>
          </size>
+        </property>
+        <property name="maximum">
+         <number>1000</number>
         </property>
        </widget>
       </item>
@@ -109,12 +115,24 @@
       </item>
      </layout>
     </item>
-    <item>
+    <item alignment="Qt::AlignHCenter">
      <widget class="QPushButton" name="startButton">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <property name="minimumSize">
        <size>
-        <width>90</width>
+        <width>75</width>
         <height>25</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>100</width>
+        <height>75</height>
        </size>
       </property>
       <property name="text">
@@ -126,7 +144,7 @@
      </widget>
     </item>
     <item>
-     <widget class="QProgressBar" name="progressBar">
+     <widget class="QProgressBar" name="recordProgressBar">
       <property name="value">
        <number>24</number>
       </property>
@@ -139,7 +157,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>638</width>
+     <width>430</width>
      <height>22</height>
     </rect>
    </property>

--- a/Holovibes/sources/batch_input_queue.cc
+++ b/Holovibes/sources/batch_input_queue.cc
@@ -108,7 +108,7 @@ void BatchInputQueue::make_empty()
     start_index_ = 0;
     end_index_ = 0;
     curr_batch_counter_ = 0;
-    has_overridden_ = false;
+    has_overwritten_ = false;
 }
 
 void BatchInputQueue::stop_producer()
@@ -169,7 +169,7 @@ void BatchInputQueue::enqueue(const void* const input_frame, const cudaMemcpyKin
         // The queue is full (in terms of batch)
         if (size_ == max_size_)
         {
-            has_overridden_ = true;
+            has_overwritten_ = true;
             start_index_ = (start_index_ + 1) % max_size_;
         }
         else
@@ -345,7 +345,7 @@ void BatchInputQueue::resize(const uint new_batch_size)
 //     {
 //         dest.start_index_ = (dest.start_index_ + dest.size_) % dest.max_size_;
 //         dest.size_.store(dest.max_size_.load());
-//         dest.has_overridden_ = true;
+//         dest.has_overwritten_ = true;
 //     }
 
 // }
@@ -419,7 +419,7 @@ void BatchInputQueue::copy_multiple(Queue& dest, const uint nb_elts, cudaMemcpyK
     {
         dest.start_index_ = (dest.start_index_ + dest.size_) % dest.max_size_;
         dest.size_.store(dest.max_size_.load());
-        dest.has_overridden_ = true;
+        dest.has_overwritten_ = true;
     }
 }
 } // namespace holovibes

--- a/Holovibes/sources/batch_input_queue.cc
+++ b/Holovibes/sources/batch_input_queue.cc
@@ -415,7 +415,7 @@ void BatchInputQueue::copy_multiple(Queue& dest, const uint nb_elts, cudaMemcpyK
     // Copy done, release the batch.
     batch_mutexes_[start_index_locked].unlock();
 
-    if (dest.size_ > dest.max_size_)
+    if (dest.size_ >= dest.max_size_)
     {
         dest.start_index_ = (dest.start_index_ + dest.size_) % dest.max_size_;
         dest.size_.store(dest.max_size_.load());

--- a/Holovibes/sources/gui/windows/MainWindow.cc
+++ b/Holovibes/sources/gui/windows/MainWindow.cc
@@ -145,11 +145,6 @@ MainWindow::MainWindow(QWidget* parent)
         api::save_compute_settings(holovibes::settings::compute_settings_filepath);
     }
 
-    // light ui
-    light_ui_ = std::make_shared<LightUI>(nullptr, this, ui_->ExportPanel, ui_->ImageRenderingPanel);
-    ui_->ExportPanel->set_light_ui(light_ui_);
-    ui_->ImageRenderingPanel->set_light_ui(light_ui_);
-
     // Display default values
     api::set_compute_mode(api::get_compute_mode());
     UserInterfaceDescriptor::instance().last_img_type_ = api::get_img_type() == ImgType::Composite
@@ -171,6 +166,11 @@ MainWindow::MainWindow(QWidget* parent)
     // Initialize all panels
     for (auto it = panels_.begin(); it != panels_.end(); it++)
         (*it)->init();
+
+    // light ui
+    light_ui_ = std::make_shared<LightUI>(nullptr, this, ui_->ExportPanel, ui_->ImageRenderingPanel);
+    ui_->ExportPanel->set_light_ui(light_ui_);
+    ui_->ImageRenderingPanel->set_light_ui(light_ui_);
 
     api::start_information_display();
 

--- a/Holovibes/sources/gui/windows/MainWindow.cc
+++ b/Holovibes/sources/gui/windows/MainWindow.cc
@@ -69,7 +69,6 @@ void spinBoxDecimalPointReplacement(QDoubleSpinBox* doubleSpinBox)
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent)
     , ui_(new Ui::MainWindow)
-    , light_ui_(nullptr)
 {
     ui_->setupUi(this);
     panels_ = {ui_->ImageRenderingPanel,
@@ -146,7 +145,7 @@ MainWindow::MainWindow(QWidget* parent)
     }
 
     // light ui
-    light_ui_ = std::make_shared<LightUI>(new LightUI(nullptr, this, ui_->ExportPanel, ui_->ImageRenderingPanel));
+    light_ui_ = std::make_shared<LightUI>(nullptr, this, ui_->ExportPanel, ui_->ImageRenderingPanel);
     ui_->ExportPanel->set_light_ui(light_ui_);
     ui_->ImageRenderingPanel->set_light_ui(light_ui_);
 
@@ -248,10 +247,6 @@ void MainWindow::on_notify()
 
     adjustSize();
 }
-
-ExportPanel* MainWindow::get_export_panel() { return ui_->ExportPanel; }
-
-ImageRenderingPanel* MainWindow::get_image_rendering_panel() { return ui_->ImageRenderingPanel; }
 
 static void handle_accumulation_exception() { api::set_xy_accumulation_level(1); }
 

--- a/Holovibes/sources/gui/windows/lightui.cc
+++ b/Holovibes/sources/gui/windows/lightui.cc
@@ -35,7 +35,7 @@ LightUI::LightUI(QWidget* parent,
     connect(ui_->OutputFileBrowseToolButton, &QPushButton::clicked, this, &LightUI::browse_record_output_file_ui);
     connect(ui_->startButton, &QPushButton::toggled, this, &LightUI::start_stop_recording);
     connect(ui_->actionConfiguration_UI, &QAction::triggered, this, &LightUI::open_configuration_ui);
-    connect(ui_->ZDoubleSpinBox, &QDoubleSpinBox::valueChanged, this, &LightUI::z_value_changed);
+    connect(ui_->ZSpinBox, &QSpinBox::valueChanged, this, &LightUI::z_value_changed);
 
     actualise_z_distance(api::get_z_distance());
 }
@@ -60,11 +60,11 @@ void LightUI::actualise_record_output_file_ui(const QString& filename)
 
 void LightUI::actualise_z_distance(const double z_distance)
 {
-    const QSignalBlocker blocker(ui_->ZDoubleSpinBox);
-    ui_->ZDoubleSpinBox->setValue(z_distance);
+    const QSignalBlocker blocker(ui_->ZSpinBox);
+    ui_->ZSpinBox->setValue(static_cast<int>(z_distance * 100));
 }
 
-void LightUI::z_value_changed(double z_distance) { image_rendering_panel_->set_z_distance_from_lightui(z_distance); }
+void LightUI::z_value_changed(int z_distance) { image_rendering_panel_->set_z_distance_from_lightui(static_cast<double>(z_distance) / 100.0f); }
 
 void LightUI::browse_record_output_file_ui()
 {

--- a/Holovibes/sources/gui/windows/lightui.cc
+++ b/Holovibes/sources/gui/windows/lightui.cc
@@ -1,4 +1,4 @@
-#include <filesystem>
+ #include <filesystem>
 
 #include "lightui.hh"
 #include "MainWindow.hh"
@@ -102,6 +102,13 @@ void LightUI::start_stop_recording(bool start)
         ui_->startButton->setStyleSheet("background-color: rgb(50, 50, 50);");
     }
     LOG_INFO(str);
+}
+
+void LightUI::reset_start_button()
+{
+    ui_->startButton->setChecked(false);
+    ui_->startButton->setText("Start");
+    ui_->startButton->setStyleSheet("background-color: rgb(50, 50, 50);");
 }
 
 void LightUI::open_configuration_ui()

--- a/Holovibes/sources/gui/windows/lightui.cc
+++ b/Holovibes/sources/gui/windows/lightui.cc
@@ -29,9 +29,13 @@ LightUI::LightUI(QWidget* parent,
     connect(ui_->OutputFileBrowseToolButton, &QPushButton::clicked, this, &LightUI::browse_record_output_file_ui);
     connect(ui_->startButton, &QPushButton::toggled, this, &LightUI::start_stop_recording);
     connect(ui_->actionConfiguration_UI, &QAction::triggered, this, &LightUI::open_configuration_ui);
-    connect(ui_->ZSpinBox, &QSpinBox::valueChanged, this, &LightUI::z_value_changed);
+    connect(ui_->ZSpinBox, &QSpinBox::valueChanged, this, &LightUI::z_value_changed_spinBox);
+    connect(ui_->ZSlider, &QSlider::valueChanged, this, &LightUI::z_value_changed_slider);
 
     actualise_z_distance(api::get_z_distance());
+
+    ui_->recordProgressBar->hide();
+    ui_->startButton->setStyleSheet("background-color: rgb(20, 20, 20);");
 }
 
 LightUI::~LightUI()
@@ -55,10 +59,24 @@ void LightUI::actualise_record_output_file_ui(const QString& filename)
 void LightUI::actualise_z_distance(const double z_distance)
 {
     const QSignalBlocker blocker(ui_->ZSpinBox);
-    ui_->ZSpinBox->setValue(static_cast<int>(z_distance * 1000));  // Convert to mm
+    const QSignalBlocker blocker2(ui_->ZSlider);
+    ui_->ZSpinBox->setValue(static_cast<int>(z_distance * 1000));
+    ui_->ZSlider->setValue(static_cast<int>(z_distance * 1000));
 }
 
-void LightUI::z_value_changed(int z_distance) { image_rendering_panel_->set_z_distance_from_lightui(static_cast<double>(z_distance) / 1000.0f); }  // Convert to m
+void LightUI::z_value_changed_spinBox(int z_distance)
+{
+    image_rendering_panel_->set_z_distance_from_lightui(static_cast<double>(z_distance) / 1000.0f);
+    const QSignalBlocker blocker(ui_->ZSlider);
+    ui_->ZSlider->setValue(z_distance);
+}
+
+void LightUI::z_value_changed_slider(int z_distance)
+{
+    image_rendering_panel_->set_z_distance_from_lightui(static_cast<double>(z_distance) / 1000.0f);
+    const QSignalBlocker blocker(ui_->ZSpinBox);
+    ui_->ZSpinBox->setValue(z_distance);
+}
 
 void LightUI::browse_record_output_file_ui()
 {
@@ -81,7 +99,7 @@ void LightUI::start_stop_recording(bool start)
         strcpy(str, "Stop recording");
         export_panel_->stop_record();
         ui_->startButton->setText("Start");
-        ui_->startButton->setStyleSheet("background-color: rgb(0, 0, 0);");
+        ui_->startButton->setStyleSheet("background-color: rgb(20, 20, 20);");
     }
     LOG_INFO(str);
 }

--- a/Holovibes/sources/gui/windows/lightui.cc
+++ b/Holovibes/sources/gui/windows/lightui.cc
@@ -119,4 +119,9 @@ void LightUI::open_configuration_ui()
     visible_ = false;
 }
 
+void LightUI::closeEvent(QCloseEvent *event)
+{
+    main_window_->close();
+}
+
 } // namespace holovibes::gui

--- a/Holovibes/sources/gui/windows/lightui.cc
+++ b/Holovibes/sources/gui/windows/lightui.cc
@@ -35,7 +35,7 @@ LightUI::LightUI(QWidget* parent,
     actualise_z_distance(api::get_z_distance());
 
     ui_->recordProgressBar->hide();
-    ui_->startButton->setStyleSheet("background-color: rgb(20, 20, 20);");
+    ui_->startButton->setStyleSheet("background-color: rgb(50, 50, 50);");
 }
 
 LightUI::~LightUI()
@@ -99,7 +99,7 @@ void LightUI::start_stop_recording(bool start)
         strcpy(str, "Stop recording");
         export_panel_->stop_record();
         ui_->startButton->setText("Start");
-        ui_->startButton->setStyleSheet("background-color: rgb(20, 20, 20);");
+        ui_->startButton->setStyleSheet("background-color: rgb(50, 50, 50);");
     }
     LOG_INFO(str);
 }

--- a/Holovibes/sources/gui/windows/lightui.cc
+++ b/Holovibes/sources/gui/windows/lightui.cc
@@ -26,12 +26,6 @@ LightUI::LightUI(QWidget* parent,
 {
     ui_->setupUi(this);
 
-    /*
-    QHBoxLayout *outputFileSelectionLayout;
-    holovibes::gui::Drag_drop_lineedit *OutputFilePathLineEdit;
-    QToolButton *OutputFileBrowseToolButton;
-    QPushButton *startButton;
-    */
     connect(ui_->OutputFileBrowseToolButton, &QPushButton::clicked, this, &LightUI::browse_record_output_file_ui);
     connect(ui_->startButton, &QPushButton::toggled, this, &LightUI::start_stop_recording);
     connect(ui_->actionConfiguration_UI, &QAction::triggered, this, &LightUI::open_configuration_ui);
@@ -61,10 +55,10 @@ void LightUI::actualise_record_output_file_ui(const QString& filename)
 void LightUI::actualise_z_distance(const double z_distance)
 {
     const QSignalBlocker blocker(ui_->ZSpinBox);
-    ui_->ZSpinBox->setValue(static_cast<int>(z_distance * 100));
+    ui_->ZSpinBox->setValue(static_cast<int>(z_distance * 1000));  // Convert to mm
 }
 
-void LightUI::z_value_changed(int z_distance) { image_rendering_panel_->set_z_distance_from_lightui(static_cast<double>(z_distance) / 100.0f); }
+void LightUI::z_value_changed(int z_distance) { image_rendering_panel_->set_z_distance_from_lightui(static_cast<double>(z_distance) / 1000.0f); }  // Convert to m
 
 void LightUI::browse_record_output_file_ui()
 {

--- a/Holovibes/sources/gui/windows/panels/export_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/export_panel.cc
@@ -90,7 +90,7 @@ void ExportPanel::set_record_frame_step(int step)
 
 int ExportPanel::get_record_frame_step() { return record_frame_step_; }
 
-void ExportPanel::set_light_ui(LightUI* light_ui)
+void ExportPanel::set_light_ui(std::shared_ptr<LightUI> light_ui)
 { 
     light_ui_ = light_ui;
     light_ui_->actualise_record_output_file_ui(ui_->OutputFilePathLineEdit->text());    

--- a/Holovibes/sources/gui/windows/panels/export_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/export_panel.cc
@@ -249,6 +249,8 @@ void ExportPanel::record_finished(RecordMode record_mode)
     ui_->ExportRecPushButton->setEnabled(true);
     ui_->ExportStopPushButton->setEnabled(false);
     ui_->BatchSizeSpinBox->setEnabled(api::get_compute_mode() == Computation::Hologram);
+
+    light_ui_->reset_start_button();
     api::record_finished();
 }
 

--- a/Holovibes/sources/gui/windows/panels/image_rendering_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/image_rendering_panel.cc
@@ -35,7 +35,7 @@ ImageRenderingPanel::~ImageRenderingPanel()
     delete z_down_shortcut_;
 }
 
-void ImageRenderingPanel::set_light_ui(LightUI* light_ui) { light_ui_ = light_ui; }
+void ImageRenderingPanel::set_light_ui(std::shared_ptr<LightUI> light_ui) { light_ui_ = light_ui; }
 
 void ImageRenderingPanel::init() { ui_->ZDoubleSpinBox->setSingleStep(z_step_); }
 

--- a/Holovibes/sources/gui/windows/panels/image_rendering_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/image_rendering_panel.cc
@@ -393,6 +393,8 @@ void ImageRenderingPanel::set_z_distance(const double value)
         return;
 
     api::set_z_distance(static_cast<float>(value));
+
+    if (!light_ui_) return;  // safety check as this function runs on startup before light_ui_ is set
     light_ui_->actualise_z_distance(value);
 }
 

--- a/Holovibes/sources/main.cc
+++ b/Holovibes/sources/main.cc
@@ -87,7 +87,7 @@ static int start_gui(holovibes::Holovibes& holovibes, int argc, char** argv, con
 
     LOG_TRACE(" ");
     if (holovibes::api::get_ui_mode())
-        window.light_ui_.show();
+        window.light_ui_->show();
     else
         window.show();
     LOG_TRACE(" ");

--- a/Holovibes/sources/queue.cc
+++ b/Holovibes/sources/queue.cc
@@ -22,7 +22,7 @@ HoloQueue::HoloQueue(QueueType type, const Device device)
     , type_(type)
     , device_(std::get<2>(*fast_updates_entry_))
     , start_index_(0)
-    , has_overridden_(false)
+    , has_overwritten_(false)
     , size_(std::get<0>(*fast_updates_entry_))
 {
     device_ = device;
@@ -104,7 +104,7 @@ void Queue::resize(const unsigned int size, const cudaStream_t stream)
 void Queue::reset()
 {
     dequeue(-1);
-    has_overridden_ = false;
+    has_overwritten_ = false;
 }
 
 bool Queue::enqueue(void* elt, const cudaStream_t stream, cudaMemcpyKind cuda_kind)
@@ -143,7 +143,7 @@ bool Queue::enqueue(void* elt, const cudaStream_t stream, cudaMemcpyKind cuda_ki
     else
     {
         start_index_ = (start_index_ + 1) % max_size_;
-        has_overridden_ = true;
+        has_overwritten_ = true;
     }
 
     return true;
@@ -220,7 +220,7 @@ void Queue::copy_multiple(Queue& dest, unsigned int nb_elts, const cudaStream_t 
     {
         dest.start_index_ = (dest.start_index_ + dest.size_) % dest.max_size_;
         dest.size_.store(dest.max_size_.load());
-        dest.has_overridden_ = true;
+        dest.has_overwritten_ = true;
     }
 
     start_index_ = tmp_src_start_index;
@@ -330,7 +330,7 @@ bool Queue::enqueue_multiple(void* elts, unsigned int nb_elts, const cudaStream_
     {
         start_index_ = (start_index_ + size_ - max_size_) % max_size_;
         size_.store(max_size_.load());
-        has_overridden_ = true;
+        has_overwritten_ = true;
     }
 
     return true;

--- a/Holovibes/sources/thread/frame_record_worker.cc
+++ b/Holovibes/sources/thread/frame_record_worker.cc
@@ -86,13 +86,13 @@ void FrameRecordWorker::run()
 
         size_t nb_frames_to_skip = setting<settings::RecordFrameSkip>();
 
-        if (Holovibes::instance().get_input_queue()->has_overridden())
+        if (Holovibes::instance().get_input_queue()->has_overwritten())
             Holovibes::instance().get_input_queue()->reset_override();
 
         while (setting<settings::RecordFrameCount>() == std::nullopt ||
                (nb_frames_recorded < setting<settings::RecordFrameCount>().value() && !stop_requested_))
         {
-            if (record_queue_.load()->has_overridden() || Holovibes::instance().get_input_queue()->has_overridden())
+            if (record_queue_.load()->has_overwritten() || Holovibes::instance().get_input_queue()->has_overwritten())
             {
                 // Due to frames being overwritten when the queue/batchInputQueue is full, the contiguity is lost.
                 if (!contiguous_frames.has_value())
@@ -101,12 +101,12 @@ void FrameRecordWorker::run()
                     contiguous_frames =
                         std::make_optional(nb_frames_recorded.load() + record_queue_.load()->get_size());
 
-                    if (record_queue_.load()->has_overridden())
+                    if (record_queue_.load()->has_overwritten())
                         LOG_WARN(
                             "The record queue has been saturated ; the record will stop once all contiguous frames "
                             "are written");
 
-                    if (Holovibes::instance().get_input_queue()->has_overridden())
+                    if (Holovibes::instance().get_input_queue()->has_overwritten())
                         LOG_WARN("The input queue has been saturated ; the record will stop once all contiguous frames "
                                  "are written");
                 }

--- a/Holovibes/sources/thread/frame_record_worker.cc
+++ b/Holovibes/sources/thread/frame_record_worker.cc
@@ -96,11 +96,20 @@ void FrameRecordWorker::run()
             {
                 // Due to frames being overwritten when the queue/batchInputQueue is full, the contiguity is lost.
                 if (!contiguous_frames.has_value())
+                {
+
                     contiguous_frames =
                         std::make_optional(nb_frames_recorded.load() + record_queue_.load()->get_size());
 
-                LOG_WARN("Frames have been lost, the record will automatically stop once the record queue writes "
-                         "all contiguous frames");
+                    if (record_queue_.load()->has_overridden())
+                        LOG_WARN(
+                            "The record queue has been saturated ; the record will stop once all contiguous frames "
+                            "are written");
+
+                    if (Holovibes::instance().get_input_queue()->has_overridden())
+                        LOG_WARN("The input queue has been saturated ; the record will stop once all contiguous frames "
+                                 "are written");
+                }
             }
 
             wait_for_frames();

--- a/Holovibes/sources/thread/frame_record_worker.cc
+++ b/Holovibes/sources/thread/frame_record_worker.cc
@@ -96,7 +96,11 @@ void FrameRecordWorker::run()
             {
                 // Due to frames being overwritten when the queue/batchInputQueue is full, the contiguity is lost.
                 if (!contiguous_frames.has_value())
-                    contiguous_frames = std::make_optional(nb_frames_recorded.load() + record_queue_.load()->get_size());
+                    contiguous_frames =
+                        std::make_optional(nb_frames_recorded.load() + record_queue_.load()->get_size());
+
+                LOG_WARN("Frames have been lost, the record will automatically stop once the record queue writes "
+                         "all contiguous frames");
             }
 
             wait_for_frames();


### PR DESCRIPTION
Several fixes:
- Crash/incorrect exit when trying to exit from light UI with a camera/file open
- Crash case on startup
- OutputFilePathLineEdit of lightUI is now corretly set on opening
- Start button now resets when the recording stops automatically