### PR TITLE
[FIX]: z distance can no longer crash kernels when at 0, fixed the spinbox bug in light ui

### DIFF
--- a/Holovibes/sources/API.cc
+++ b/Holovibes/sources/API.cc
@@ -965,6 +965,10 @@ void set_lambda(float value)
 
 void set_z_distance(float value)
 {
+    if (value == 0)
+    {
+        value = 0.000001;
+    } // to avoid kernel crash with 0 distance
     // Notify the change to the z_distance notifier
     auto& manager = NotifierManager::get_instance();
     auto zDistanceNotifier = manager.get_notifier<double>("z_distance");

--- a/Holovibes/sources/gui/windows/lightui.cc
+++ b/Holovibes/sources/gui/windows/lightui.cc
@@ -1,4 +1,5 @@
 #include <filesystem>
+#include <cmath> // Pour std::round
 
 #include "lightui.hh"
 #include "MainWindow.hh"
@@ -60,8 +61,8 @@ void LightUI::actualise_z_distance(const double z_distance)
 {
     const QSignalBlocker blocker(ui_->ZSpinBox);
     const QSignalBlocker blocker2(ui_->ZSlider);
-    ui_->ZSpinBox->setValue(static_cast<int>(z_distance * 1000));
-    ui_->ZSlider->setValue(static_cast<int>(z_distance * 1000));
+    ui_->ZSpinBox->setValue(static_cast<int>(std::round(z_distance * 1000)));
+    ui_->ZSlider->setValue(static_cast<int>(std::round(z_distance * 1000)));
 }
 
 void LightUI::z_value_changed_spinBox(int z_distance)
@@ -129,7 +130,6 @@ void LightUI::set_visible_record_progress(bool visible)
         ui_->recordProgressBar->reset();
         ui_->recordProgressBar->setFormat("Idle");
     }
-
 }
 
 void LightUI::set_recordProgressBar_color(const QColor& color, const QString& text)


### PR DESCRIPTION
- z distance can no longer crash kernels when at 0.
- Fixed the spinbox bug in light ui.