### PR TITLE
[FIX] compute settings gpu buffers aren't imported when loading a file to avoid surcharging the gpu + flatfield correction off by default

### DIFF
--- a/Camera/configs/ametek_s710_euresys_coaxlink_octo.ini
+++ b/Camera/configs/ametek_s710_euresys_coaxlink_octo.ini
@@ -40,7 +40,7 @@ GainSelector = DigitalAll
 Gain = 1.00
 
 ; FlatFieldCorretionOn | FlatFieldCorrectionOff
-FlatFieldCorrection = FlatFieldCorrectionOn
+FlatFieldCorrection = FlatFieldCorrectionOff
 
 ; BalanceWhiteMarkerOn | BalanceWhiteMarkerOff
 BalanceWhiteMarker = BalanceWhiteMarkerOff

--- a/Camera/configs/ametek_s711_euresys_coaxlink_qsfp+.ini
+++ b/Camera/configs/ametek_s711_euresys_coaxlink_qsfp+.ini
@@ -42,7 +42,7 @@ GainSelector = DigitalAll
 Gain = 1.00
 
 ; On | Off
-FlatFieldCorrection = On
+FlatFieldCorrection = Off
 
 ; On | Off
 BalanceWhiteMarker = Off

--- a/Holovibes/sources/gui/windows/panels/import_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/import_panel.cc
@@ -102,9 +102,15 @@ void ImportPanel::import_file(const QString& filename)
     {
         auto input_file = input_file_opt.value();
 
+        // Get the buffer size that will be used to allocate the buffer for reading the file instead of the one from the
+        // record
+        auto input_buffer_size = api::get_input_buffer_size();
+        auto record_buffer_size = api::get_record_buffer_size();
+
         // Import Compute Settings there before init_pipe to
         // Allocate correctly buffer
-        try {
+        try
+        {
             input_file->import_compute_settings();
             input_file->import_info();
         }
@@ -116,6 +122,11 @@ void ImportPanel::import_file(const QString& filename)
             LOG_INFO("Compute settings incorrect or file not found. Initialization with default values.");
             api::save_compute_settings(holovibes::settings::compute_settings_filepath);
         }
+
+        // update the buffer size with the old values to avoid surcharging the gpu memory in case of big buffers used
+        // when the file was recorded
+        api::set_input_buffer_size(input_buffer_size);
+        api::set_record_buffer_size(record_buffer_size);
 
         parent_->notify();
 
@@ -159,7 +170,7 @@ void ImportPanel::import_start()
     if (!api::get_is_computation_stopped())
         import_stop();
 
-    //parent_->shift_screen();
+    // parent_->shift_screen();
 
     bool res_import_start = api::import_start();
 
@@ -205,7 +216,7 @@ void ImportPanel::update_input_file_start_index()
 {
     QSpinBox* start_spinbox = ui_->ImportStartIndexSpinBox;
 
-    api::set_input_file_start_index(start_spinbox->value() - 1); 
+    api::set_input_file_start_index(start_spinbox->value() - 1);
 
     start_spinbox->setValue(api::get_input_file_start_index() + 1);
 
@@ -217,8 +228,8 @@ void ImportPanel::update_input_file_start_index()
     }
 }
 
-void ImportPanel::update_input_file_end_index() 
-{ 
+void ImportPanel::update_input_file_end_index()
+{
     QSpinBox* end_spinbox = ui_->ImportEndIndexSpinBox;
 
     api::set_input_file_end_index(ui_->ImportEndIndexSpinBox->value());


### PR DESCRIPTION
- Compute settings gpu buffers aren't imported when loading a file to avoid surcharging the gpu 
- Flatfield correction off by default in cameras ini files