### PR TITLE
Date in export name + file name smart reading

### DIFF
--- a/Holovibes/includes/gui/windows/lightui.hh
+++ b/Holovibes/includes/gui/windows/lightui.hh
@@ -49,7 +49,7 @@ class LightUI : public QMainWindow
      * @brief Updates the UI with the output file name for recording.
      * @param filename The name of the output file.
      */
-    void actualise_record_output_file_ui(const QString& filename);
+    void actualise_record_output_file_ui(const std::filesystem::path file_path);
 
     /**
      * @brief Updates the UI with the Z distance.

--- a/Holovibes/mainwindow.ui
+++ b/Holovibes/mainwindow.ui
@@ -2467,7 +2467,7 @@
                  <string>...</string>
                 </property>
                 <property name="shortcut">
-                 <string>Ctrl+O</string>
+                 <string>Ctrl+I</string>
                 </property>
                </widget>
               </item>
@@ -2607,6 +2607,9 @@
                 </property>
                 <property name="text">
                  <string>Start</string>
+                </property>
+                <property name="shortcut">
+                 <string>Ctrl+O</string>
                 </property>
                </widget>
               </item>

--- a/Holovibes/mainwindow.ui
+++ b/Holovibes/mainwindow.ui
@@ -2467,7 +2467,7 @@
                  <string>...</string>
                 </property>
                 <property name="shortcut">
-                 <string>Ctrl+I</string>
+                 <string>Ctrl+O</string>
                 </property>
                </widget>
               </item>
@@ -2609,7 +2609,7 @@
                  <string>Start</string>
                 </property>
                 <property name="shortcut">
-                 <string>Ctrl+O</string>
+                 <string>Ctrl+T</string>
                 </property>
                </widget>
               </item>

--- a/Holovibes/sources/API.cc
+++ b/Holovibes/sources/API.cc
@@ -3,6 +3,8 @@
 #include "input_filter.hh"
 #include "notifier.hh"
 
+#include <regex>
+#include <string>
 #include <unordered_map>
 
 namespace holovibes::api
@@ -1686,6 +1688,22 @@ void stop_chart_display()
 
 #pragma region Record
 
+/**
+ * @brief Extract the name from the filename
+ * 
+ * @param filePath the file name
+ * @return std::string the name extracted from the filename
+ */
+std::string getNameFromFilename(const std::string& filename)
+{
+    std::regex filenamePattern{R"((\d{6}_)([a-zA-Z0-9]*)?(_\d+)*$)"};
+    std::smatch matches;
+    if (std::regex_search(filename, matches, filenamePattern))
+        return matches[2].str();
+    else
+        return filename; // Returning the original filename if no match is found
+}
+
 const std::string browse_record_output_file(std::string& std_filepath)
 {
     // Let std::filesystem handle path normalization and system compatibility
@@ -1694,7 +1712,7 @@ const std::string browse_record_output_file(std::string& std_filepath)
     // Using std::filesystem to derive parent path, extension, and stem directly
     std::string parentPath = normalizedPath.parent_path().string();
     std::string fileExt = normalizedPath.extension().string();
-    std::string fileNameWithoutExt = normalizedPath.stem().string();
+    std::string fileNameWithoutExt = getNameFromFilename(normalizedPath.stem().string());
 
     // Setting values in UserInterfaceDescriptor instance in a more optimized manner
     UserInterfaceDescriptor::instance().record_output_directory_ = std::move(parentPath);

--- a/Holovibes/sources/API.cc
+++ b/Holovibes/sources/API.cc
@@ -1696,10 +1696,10 @@ void stop_chart_display()
  */
 std::string getNameFromFilename(const std::string& filename)
 {
-    std::regex filenamePattern{R"((\d{6}_)([a-zA-Z0-9]*)?(_\d+)*$)"};
+    std::regex filenamePattern{R"(^\d{6}_(.*?)_?\d*$)"};
     std::smatch matches;
     if (std::regex_search(filename, matches, filenamePattern))
-        return matches[2].str();
+        return matches[1].str();
     else
         return filename; // Returning the original filename if no match is found
 }

--- a/Holovibes/sources/gui/windows/lightui.cc
+++ b/Holovibes/sources/gui/windows/lightui.cc
@@ -36,6 +36,7 @@ LightUI::LightUI(QWidget* parent, MainWindow* main_window, ExportPanel* export_p
     connect(ui_->ZSlider, &QSlider::valueChanged, this, &LightUI::z_value_changed_slider);
 
     ui_->startButton->setStyleSheet("background-color: rgb(50, 50, 50);");
+    ui_->startButton->setShortcut(Qt::CTRL + Qt::Key_R);
 }
 
 LightUI::~LightUI()

--- a/Holovibes/sources/gui/windows/lightui.cc
+++ b/Holovibes/sources/gui/windows/lightui.cc
@@ -52,12 +52,11 @@ void LightUI::showEvent(QShowEvent* event)
     visible_ = true;
 }
 
-void LightUI::actualise_record_output_file_ui(const QString& file_path)
+void LightUI::actualise_record_output_file_ui(const std::filesystem::path file_path)
 {
-    ui_->OutputFilePathLineEdit->setText(QFileInfo(file_path).path());
-    auto file_name = QFileInfo(file_path).fileName();
+    ui_->OutputFilePathLineEdit->setText(QString::fromStdString(file_path.parent_path().string()));
     // remove the extension from the filename
-    ui_->OutputFileNameLineEdit->setText(file_name.left(file_name.lastIndexOf('.')));
+    ui_->OutputFileNameLineEdit->setText(QString::fromStdString(file_path.stem().string()));
 }
 
 void LightUI::actualise_z_distance(const double z_distance)

--- a/Holovibes/sources/gui/windows/lightui.cc
+++ b/Holovibes/sources/gui/windows/lightui.cc
@@ -82,8 +82,10 @@ void LightUI::browse_record_output_file_ui()
     //! create a new browser in this class and then use notify to send the file path to the API (and synchronize the API
     //! with the file path).
     auto file_path = export_panel_->browse_record_output_file();
-    ui_->OutputFilePathLineEdit->setText(QFileInfo(file_path).path());
-    auto file_name = QFileInfo(file_path).fileName();
+    auto file_info = QFileInfo(file_path);
+    ui_->OutputFilePathLineEdit->setText(file_info.path());
+
+    auto file_name = file_info.fileName();
     // remove the extension from the filename
     ui_->OutputFileNameLineEdit->setText(file_name.left(file_name.lastIndexOf('.')));
 }

--- a/Holovibes/sources/gui/windows/panels/export_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/export_panel.cc
@@ -77,6 +77,7 @@ void ExportPanel::on_notify()
          UserInterfaceDescriptor::instance().output_filename_)
             .string();
     path_line_edit->insert(record_output_path.c_str());
+    light_ui_->actualise_record_output_file_ui(record_output_path.toStdString());
 
     ui_->RecordDeviceCheckbox->setEnabled(api::get_record_mode() == RecordMode::RAW);
     ui_->RecordDeviceCheckbox->setChecked(!api::get_record_on_gpu());
@@ -148,7 +149,6 @@ QString ExportPanel::browse_record_output_file()
     // Will pick the item combobox related to file_ext if it exists, else, nothing is done
     ui_->RecordExtComboBox->setCurrentText(file_ext.c_str());
 
-    light_ui_->actualise_record_output_file_ui(filepath);
     parent_->notify();
 
     return filepath;

--- a/Holovibes/sources/gui/windows/panels/export_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/export_panel.cc
@@ -77,7 +77,8 @@ void ExportPanel::on_notify()
          UserInterfaceDescriptor::instance().output_filename_)
             .string();
     path_line_edit->insert(record_output_path.c_str());
-    light_ui_->actualise_record_output_file_ui(record_output_path.toStdString());
+    if (light_ui_ != nullptr)
+        light_ui_->actualise_record_output_file_ui(record_output_path);
 
     ui_->RecordDeviceCheckbox->setEnabled(api::get_record_mode() == RecordMode::RAW);
     ui_->RecordDeviceCheckbox->setChecked(!api::get_record_on_gpu());
@@ -101,7 +102,8 @@ int ExportPanel::get_record_frame_step() { return record_frame_step_; }
 void ExportPanel::set_light_ui(std::shared_ptr<LightUI> light_ui)
 {
     light_ui_ = light_ui;
-    light_ui_->actualise_record_output_file_ui(ui_->OutputFilePathLineEdit->text());
+    light_ui_->actualise_record_output_file_ui(
+        std::filesystem::path(ui_->OutputFilePathLineEdit->text().toStdString()));
 }
 
 QString ExportPanel::browse_record_output_file()

--- a/Holovibes/sources/thread/frame_record_worker.cc
+++ b/Holovibes/sources/thread/frame_record_worker.cc
@@ -50,7 +50,9 @@ std::string get_current_date()
     auto in_time_t = std::chrono::system_clock::to_time_t(now);
 
     std::stringstream ss;
-    ss << std::put_time(std::localtime(&in_time_t), "%Y%m%d_");
+    std::tm* timeinfo = std::localtime(&in_time_t);
+    int year = timeinfo->tm_year % 100;
+    ss << std::setw(2) << std::setfill('0') << year << std::put_time(timeinfo, "%m%d_");
     return ss.str();
 }
 

--- a/Holovibes/sources/thread/frame_record_worker.cc
+++ b/Holovibes/sources/thread/frame_record_worker.cc
@@ -56,6 +56,17 @@ std::string get_current_date()
     return ss.str();
 }
 
+std::string append_date_to_filepath(std::string filepath)
+{
+    //? Do we move this to the export panel, and consider the date to be set when the path is set/on startup ?
+    std::filesystem::path filePath(record_file_path);
+    std::string date = get_current_date();
+    std::string filename = filePath.filename().string();
+    std::string path = filePath.parent_path().string();
+    std::filesystem::path newFilePath = path + "/" + date + filename;
+    record_file_path = newFilePath.string();
+}
+
 void FrameRecordWorker::run()
 {
     onrestart_settings_.apply_updates();
@@ -89,15 +100,7 @@ void FrameRecordWorker::run()
 
     try
     {
-        //? Do we move this to the export panel, and consider the date to be set when the path is set/on startup ?
-        std::string record_file_path = setting<settings::RecordFilePath>();
-        std::filesystem::path filePath(record_file_path);
-        std::string date = get_current_date();
-        std::string filename = filePath.filename().string();
-        std::string path = filePath.parent_path().string();
-        std::filesystem::path newFilePath = path + "/" + date + filename;
-        record_file_path = newFilePath.string();
-
+        std::string record_file_path = append_date_to_filepath(setting<settings::RecordFilePath>());
 
         output_frame_file = io_files::OutputFrameFileFactory::create(record_file_path,
                                                                      record_queue_.load()->get_fd(),


### PR DESCRIPTION
- When saving a file, it now automatically add the current date as a prefix (please have the clock of your computer correctly set)
- When selecting an existing file for its name, it'll automatically trim the date and number prefix and suffix.