### PR TITLE
Fix cli

### DIFF
--- a/Holovibes/includes/API.hxx
+++ b/Holovibes/includes/API.hxx
@@ -846,21 +846,6 @@ inline RecordMode get_record_mode()
     return holovibes::Holovibes::instance().get_setting<holovibes::settings::RecordMode>().value;
 }
 
-inline std::string get_record_mode_string()
-{
-    switch (get_record_mode())
-    {
-    case RecordMode::RAW:
-        return "Raw Image";
-    case RecordMode::HOLOGRAM:
-        return "Processed Image";
-    case RecordMode::CHART:
-        return "Chart";
-    default:
-        return "NONE";
-    }
-}
-
 inline void set_record_mode(RecordMode value)
 {
     holovibes::Holovibes::instance().update_setting(holovibes::settings::RecordMode{value});

--- a/Holovibes/includes/core/holovibes.hh
+++ b/Holovibes/includes/core/holovibes.hh
@@ -371,7 +371,7 @@ class Holovibes
 
     /*! \brief Construct the holovibes object. */
     Holovibes()
-        : realtime_settings_(std::make_tuple(settings::InputFPS{60},
+        : realtime_settings_(std::make_tuple(settings::InputFPS{10000},
                                              settings::InputFilePath{std::string("")},
                                              settings::FileBufferSize{1024},
                                              settings::LoopOnInputFile{true},

--- a/Holovibes/includes/struct/advanced_struct.hh
+++ b/Holovibes/includes/struct/advanced_struct.hh
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "all_struct.hh"
-#include "enum_record_mode.hh"
 #include <optional>
 
 namespace holovibes
@@ -77,20 +76,13 @@ struct AdvancedSettings
     unsigned renorm_constant = 5;
     unsigned int raw_bitshift = 0;
     unsigned int nb_frames_to_record = 0;
-    RecordMode record_mode = RecordMode::RAW;
 
     void Update();
     void Load();
     void Assert() const;
 
-    SERIALIZE_JSON_STRUCT(AdvancedSettings,
-                          buffer_size,
-                          filter2d_smooth,
-                          contrast,
-                          renorm_constant,
-                          raw_bitshift,
-                          nb_frames_to_record,
-                          record_mode)
+    SERIALIZE_JSON_STRUCT(
+        AdvancedSettings, buffer_size, filter2d_smooth, contrast, renorm_constant, raw_bitshift, nb_frames_to_record)
 };
 
 } // namespace holovibes

--- a/Holovibes/includes/struct/internals_struct.hh
+++ b/Holovibes/includes/struct/internals_struct.hh
@@ -40,7 +40,7 @@ struct Internals
      */
     struct Record
     {
-        float input_fps = 60.0f;
+        float input_fps = 10000.0f;
         unsigned record_start_frame = 0;
         unsigned record_end_frame = 0;
         bool frame_record_enabled = false;

--- a/Holovibes/sources/cli.cc
+++ b/Holovibes/sources/cli.cc
@@ -104,29 +104,20 @@ int get_first_and_last_frame(const holovibes::OptionsDescriptor& opts, const uin
 
 static int set_parameters(holovibes::Holovibes& holovibes, const holovibes::OptionsDescriptor& opts)
 {
-    auto mode = opts.record_raw ? holovibes::RecordMode::RAW : holovibes::RecordMode::HOLOGRAM;
-    
-    holovibes.update_setting(holovibes::settings::RecordMode{mode});
-
-    holovibes::api::set_frame_record_enabled(true);
-    holovibes::api::set_compute_mode(opts.record_raw ? holovibes::Computation::Raw : holovibes::Computation::Hologram);
-
-    holovibes::api::set_record_mode(opts.record_raw ? holovibes::RecordMode::RAW : holovibes::RecordMode::HOLOGRAM);
 #ifdef _DEBUG
     holovibes::api::set_benchmark_mode(opts.benchmark);
 #endif
 
     std::string input_path = opts.input_path.value();
     holovibes::api::set_input_file_path(input_path);
-    
-    holovibes::io_files::InputFrameFile* input_frame_file = holovibes::io_files::InputFrameFileFactory::open(input_path);
+
+    holovibes::io_files::InputFrameFile* input_frame_file =
+        holovibes::io_files::InputFrameFileFactory::open(input_path);
     if (!input_frame_file)
     {
         LOG_ERROR("Failed to open input file");
         return 33;
     }
-
-    
 
     bool load = false;
     if (input_frame_file->get_has_footer())
@@ -167,10 +158,19 @@ static int set_parameters(holovibes::Holovibes& holovibes, const holovibes::Opti
         return 35;
     }
 
+    auto mode = opts.record_raw ? holovibes::RecordMode::RAW : holovibes::RecordMode::HOLOGRAM;
+
+    holovibes.update_setting(holovibes::settings::RecordMode{mode});
+
+    holovibes::api::set_frame_record_enabled(true);
+    holovibes::api::set_compute_mode(opts.record_raw ? holovibes::Computation::Raw : holovibes::Computation::Hologram);
+
+    holovibes::api::set_record_mode(opts.record_raw ? holovibes::RecordMode::RAW : holovibes::RecordMode::HOLOGRAM);
+
     const camera::FrameDescriptor& fd = input_frame_file->get_frame_descriptor();
 
     if (int ret = get_first_and_last_frame(opts, static_cast<uint>(input_frame_file->get_total_nb_frames())))
-        return ret;  // error 31, 32
+        return ret; // error 31, 32
 
     holovibes.init_input_queue(fd, holovibes::api::get_input_buffer_size());
 
@@ -210,8 +210,10 @@ static void main_loop(holovibes::Holovibes& holovibes)
     // Request auto contrast once if auto refresh is enabled
     bool requested_autocontrast = !holovibes::api::get_xy_contrast_auto_refresh();
 
-    while (holovibes::api::get_frame_record_enabled()) {
-        if (holovibes::GSH::fast_updates_map<holovibes::ProgressType>.contains(holovibes::ProgressType::FRAME_RECORD)) {
+    while (holovibes::api::get_frame_record_enabled())
+    {
+        if (holovibes::GSH::fast_updates_map<holovibes::ProgressType>.contains(holovibes::ProgressType::FRAME_RECORD))
+        {
             if (!progress)
                 progress = holovibes::GSH::fast_updates_map<holovibes::ProgressType>.get_entry(
                     holovibes::ProgressType::FRAME_RECORD);
@@ -233,7 +235,7 @@ static void main_loop(holovibes::Holovibes& holovibes)
         // Don't make the current thread loop too fast
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-   
+
     // Show 100% completion to avoid rounding errors
     progress_bar(1, 1, 40);
 }
@@ -244,9 +246,19 @@ static int start_cli_workers(holovibes::Holovibes& holovibes, const holovibes::O
     // Force some values
 
     // Value used in more than 1 thread
-    size_t input_nb_frames =
-        holovibes::api::get_input_file_end_index() - holovibes::api::get_input_file_start_index();
-    uint record_nb_frames = opts.n_rec.value_or(input_nb_frames / holovibes::api::get_time_stride());
+    size_t input_nb_frames = holovibes::api::get_input_file_end_index() - holovibes::api::get_input_file_start_index();
+    uint record_nb_frames;
+    if (opts.record_raw)
+    {
+        record_nb_frames = opts.n_rec.value_or(input_nb_frames);
+        LOG_ERROR("ICI");
+    }
+    else
+    {
+        record_nb_frames = opts.n_rec.value_or(input_nb_frames / holovibes::api::get_time_stride());
+        LOG_ERROR("LA");
+    }
+
     if (record_nb_frames <= 0)
     {
         LOG_ERROR("Asking to record {} frames, abort", std::to_string(record_nb_frames));
@@ -262,7 +274,7 @@ static int start_cli_workers(holovibes::Holovibes& holovibes, const holovibes::O
     holovibes.update_setting(holovibes::settings::RecordFilePath{opts.output_path.value()});
     holovibes.update_setting(holovibes::settings::RecordFrameCount{record_nb_frames});
     holovibes.update_setting(holovibes::settings::RecordFrameSkip{nb_frames_skip});
-    
+
     holovibes.start_frame_record();
 
     // The following while ensure the record has been requested by the thread previously launched.

--- a/Holovibes/sources/cli.cc
+++ b/Holovibes/sources/cli.cc
@@ -251,12 +251,10 @@ static int start_cli_workers(holovibes::Holovibes& holovibes, const holovibes::O
     if (opts.record_raw)
     {
         record_nb_frames = opts.n_rec.value_or(input_nb_frames);
-        LOG_ERROR("ICI");
     }
     else
     {
         record_nb_frames = opts.n_rec.value_or(input_nb_frames / holovibes::api::get_time_stride());
-        LOG_ERROR("LA");
     }
 
     if (record_nb_frames <= 0)

--- a/Holovibes/sources/cli.cc
+++ b/Holovibes/sources/cli.cc
@@ -120,7 +120,23 @@ static int set_parameters(holovibes::Holovibes& holovibes, const holovibes::Opti
     }
 
     bool load = false;
-    if (input_frame_file->get_has_footer())
+    
+    if (opts.compute_settings_path)
+    {
+        try
+        {
+            holovibes::api::load_compute_settings(opts.compute_settings_path.value());
+        }
+        catch (std::exception& e)
+        {
+            LOG_INFO(e.what());
+            LOG_INFO("Error while loading compute settings, abort");
+            return 34;
+        }
+        load = true;
+    }
+
+    else if (input_frame_file->get_has_footer())
     {
         LOG_DEBUG("loading pixel size");
         // Pixel size is set with info section of input file we need to call import_compute_settings in order to load
@@ -138,21 +154,7 @@ static int set_parameters(holovibes::Holovibes& holovibes, const holovibes::Opti
         }
         load = true;
     }
-
-    if (opts.compute_settings_path)
-    {
-        try
-        {
-            holovibes::api::load_compute_settings(opts.compute_settings_path.value());
-        }
-        catch (std::exception& e)
-        {
-            LOG_INFO(e.what());
-            LOG_INFO("Error while loading compute settings, abort");
-            return 34;
-        }
-    }
-    else if (!load)
+    if (!load)
     {
         LOG_DEBUG("No compute settings file provided and no footer found in input file");
         return 35;

--- a/Holovibes/sources/cli.cc
+++ b/Holovibes/sources/cli.cc
@@ -266,7 +266,7 @@ static int start_cli_workers(holovibes::Holovibes& holovibes, const holovibes::O
     // Thread 1
     uint nb_frames_skip = 0;
     // Skip img acc frames to avoid early black frames
-    if (!opts.noskip_acc && holovibes::api::get_xy_img_accu_enabled())
+    if (!opts.noskip_acc && holovibes::api::get_xy_img_accu_enabled() && !opts.record_raw)
         nb_frames_skip = holovibes::api::get_xy_accumulation_level();
 
     holovibes.update_setting(holovibes::settings::RecordFilePath{opts.output_path.value()});

--- a/Holovibes/sources/gui/windows/panels/export_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/export_panel.cc
@@ -15,8 +15,8 @@ namespace api = ::holovibes::api;
 namespace holovibes::gui
 {
 ExportPanel::ExportPanel(QWidget* parent)
-    : Panel(parent), import_start_subscriber_("import_start", [this](bool success)
-                                                { set_record_image_mode(); })
+    : Panel(parent)
+    , import_start_subscriber_("import_start", [this](bool success) { set_record_image_mode(); })
 {
 }
 
@@ -25,10 +25,7 @@ ExportPanel::~ExportPanel() {}
 void ExportPanel::init()
 {
     ui_->NumberOfFramesSpinBox->setSingleStep(record_frame_step_);
-    if (api::get_compute_mode() == Computation::Raw || api::get_record_mode() == RecordMode::RAW)
-        set_record_mode(QString::fromUtf8("Raw Image"));
-    else
-        api::set_record_mode(api::get_record_mode());
+    set_record_mode(QString::fromUtf8("Raw Image"));
 }
 
 void ExportPanel::on_notify()
@@ -45,9 +42,6 @@ void ExportPanel::on_notify()
         if (ui_->RecordImageModeComboBox->findText("Chart") == -1)
             ui_->RecordImageModeComboBox->insertItem(2, "Chart");
     }
-
-    // select the record mode in the settings
-    ui_->RecordImageModeComboBox->setCurrentText(QString::fromStdString(api::get_record_mode_string()));
 
     if (ui_->TimeTransformationCutsCheckBox->isChecked())
     {

--- a/Holovibes/sources/gui/windows/panels/import_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/import_panel.cc
@@ -30,7 +30,7 @@ void ImportPanel::load_gui(const json& j_us)
     ui_->actionImportExport->setChecked(!h);
     ui_->ImportExportFrame->setHidden(h);
 
-    ui_->ImportInputFpsSpinBox->setValue(json_get_or_default(j_us, 60, "import", "fps"));
+    ui_->ImportInputFpsSpinBox->setValue(json_get_or_default(j_us, 10000, "import", "fps"));
     update_fps(); // Required as it is called `OnEditedFinished` only.
 
     ui_->LoadFileInGpuCheckBox->setChecked(json_get_or_default(j_us, false, "import", "from gpu"));

--- a/Holovibes/sources/io_files/input_holo_file.cc
+++ b/Holovibes/sources/io_files/input_holo_file.cc
@@ -127,7 +127,7 @@ void InputHoloFile::load_footer()
 
 void rec_fill_default_json(json& dst, json& src)
 {
-    for(auto dst_el = dst.begin(); dst_el != dst.end(); ++dst_el)
+    for (auto dst_el = dst.begin(); dst_el != dst.end(); ++dst_el)
     {
         if (src.contains(dst_el.key()))
         {
@@ -203,6 +203,7 @@ void InputHoloFile::import_info() const
     {
         // Pixel are considered square
         api::set_pixel_size(meta_data_["info"]["pixel_pitch"]["x"]);
+        api::set_input_fps(meta_data_["info"]["input_fps"]);
     }
     catch (std::exception&)
     {

--- a/Holovibes/sources/io_files/output_mp4_file.cc
+++ b/Holovibes/sources/io_files/output_mp4_file.cc
@@ -23,7 +23,11 @@ void OutputMp4File::write_header()
 
         bool is_color = fd_.depth == 3;
 
-        video_writer_ = cv::VideoWriter(file_path_, fourcc, compute_output_fps(), size, is_color);
+        // double output_fps = compute_output_fps(); // 24 is good enough, and otherwise finding the right value is a pain
+        // if (output_fps > 5000)  // 5000 is an arbitrary limit
+        //     output_fps = 5000;
+
+        video_writer_ = cv::VideoWriter(file_path_, fourcc, 24, size, is_color);
 
         if (!video_writer_.isOpened())
             throw cv::Exception();

--- a/Holovibes/sources/struct/all_struct.cc
+++ b/Holovibes/sources/struct/all_struct.cc
@@ -109,7 +109,6 @@ void AdvancedSettings::Update()
     if (holovibes::Holovibes::instance().get_setting<settings::RecordFrameCount>().value.has_value())
         this->nb_frames_to_record =
             holovibes::Holovibes::instance().get_setting<settings::RecordFrameCount>().value.value();
-    this->record_mode = holovibes::Holovibes::instance().get_setting<settings::RecordMode>().value;
 }
 
 void Composite::Update()
@@ -160,7 +159,6 @@ void AdvancedSettings::Load()
     Holovibes::instance().update_setting(settings::RawBitshift{this->raw_bitshift});
     if (this->nb_frames_to_record != 0)
         Holovibes::instance().update_setting(settings::RecordFrameCount{this->nb_frames_to_record});
-    Holovibes::instance().update_setting(settings::RecordMode{this->record_mode});
 }
 
 void Composite::Load()

--- a/Preset/DOPPLER.json
+++ b/Preset/DOPPLER.json
@@ -18,7 +18,6 @@
      },
      "nb_frames_to_record": 65536,
      "raw_bitshift": 0,
-     "record_mode": "RAW",
      "renorm_constant": 5
     },
     "color_composite_image": {

--- a/Preset/OCT.json
+++ b/Preset/OCT.json
@@ -18,7 +18,6 @@
      },
      "nb_frames_to_record": 65536,
      "raw_bitshift": 0,
-     "record_mode": "RAW",
      "renorm_constant": 5
     },
     "color_composite_image": {

--- a/Preset/preset.json
+++ b/Preset/preset.json
@@ -18,7 +18,6 @@
      },
      "nb_frames_to_record": 65536,
      "raw_bitshift": 0,
-     "record_mode": "RAW",
      "renorm_constant": 5
     },
     "color_composite_image": {

--- a/ProcessHoloFiles.ps1
+++ b/ProcessHoloFiles.ps1
@@ -1,0 +1,91 @@
+# Import the necessary assembly for file dialog
+Add-Type -AssemblyName System.Windows.Forms
+
+# Function to prompt the user to select a folder
+function Select-Folder([string]$description) {
+    $folderBrowser = New-Object System.Windows.Forms.FolderBrowserDialog
+    $folderBrowser.Description = $description
+    $dialogResult = $folderBrowser.ShowDialog()
+    
+    if ($dialogResult -eq [System.Windows.Forms.DialogResult]::OK) {
+        return $folderBrowser.SelectedPath
+    } else {
+        return $null
+    }
+}
+
+# Function to prompt the user to select a file
+function Select-File([string]$description, [string]$filter) {
+    $fileDialog = New-Object System.Windows.Forms.OpenFileDialog
+    $fileDialog.Filter = $filter
+    $fileDialog.Title = $description
+    $dialogResult = $fileDialog.ShowDialog()
+    
+    if ($dialogResult -eq [System.Windows.Forms.DialogResult]::OK) {
+        return $fileDialog.FileName
+    } else {
+        return $null
+    }
+}
+
+# Prompt the user to select the folder containing .holo files
+$holoFolderPath = Select-Folder -description "Select the folder containing .holo files"
+
+# Check if the user selected a folder
+if (-not $holoFolderPath) {
+    Write-Host "No folder was selected. Exiting script." -ForegroundColor Red
+    exit
+}
+
+# Prompt the user to select the configuration file
+$configFilePath = Select-File -description "Select the configuration file" -filter "Config Files (*.json)|*.json|All Files (*.*)|*.*"
+
+# Check if the user selected a config file
+if (-not $configFilePath) {
+    Write-Host "No configuration file was selected. Exiting script." -ForegroundColor Red
+    exit
+}
+
+# Prompt the user to select the Holovibes executable
+$exePath = Select-File -description "Select the Holovibes executable" -filter "Executable Files (*.exe)|*.exe|All Files (*.*)|*.*"
+
+# Check if the user selected the executable
+if (-not $exePath) {
+    Write-Host "No executable was selected. Exiting script." -ForegroundColor Red
+    exit
+}
+
+# Confirm action with the user
+Write-Host "You have selected the folder: $holoFolderPath" -ForegroundColor Cyan
+Write-Host "You have selected the configuration file: $configFilePath" -ForegroundColor Cyan
+Write-Host "You have selected the Holovibes executable: $exePath" -ForegroundColor Cyan
+Read-Host "Press Enter to continue or Ctrl+C to exit"
+
+# Get a list of all .holo files in the selected folder
+$holoFiles = Get-ChildItem -Path $holoFolderPath -Filter *.holo
+
+# Display the list of .holo files with colorful output
+Write-Host "Listing .holo files in the selected folder:" -ForegroundColor Cyan
+$counter = 1
+foreach ($file in $holoFiles) {
+    Write-Host "$counter. $($file.Name)" -ForegroundColor Green
+    $counter++
+}
+
+# Confirm action with the user before processing files
+Read-Host "Press Enter to start processing files or Ctrl+C to exit"
+
+# Execute Holovibes.exe for each .holo file
+foreach ($file in $holoFiles) {
+    $inputFilePath = $file.FullName
+    $outputFileName = "$($file.BaseName)_out.mp4"
+    $outputFilePath = Join-Path $holoFolderPath $outputFileName
+
+    # Run Holovibes.exe with the .holo file, specifying the output file name and config
+    Write-Host "Processing $($file.Name)..." -ForegroundColor Yellow
+    Start-Process -FilePath $exePath -ArgumentList "-i `"$inputFilePath`" -o `"$outputFilePath`" -c `"$configFilePath`"" -NoNewWindow -Wait
+    Write-Host "Finished processing $($file.Name), output saved as $outputFileName" -ForegroundColor Green
+}
+
+Write-Host "All files processed successfully." -ForegroundColor Cyan
+Read-Host "Press Enter to exit."


### PR DESCRIPTION
--fps option fixed
- cli now works properly for new holovibe's version footer
- mp4 file output is not hard set to 24 fps (avi isn't)
- record_mode isn't a compute_setting anymore
- default inputfps value is now 10000 (from 60)