### PR TITLE
Fix buffer size (issue #478)

### DIFF
--- a/Holovibes/includes/gui/other/popup_error.hh
+++ b/Holovibes/includes/gui/other/popup_error.hh
@@ -13,4 +13,10 @@ namespace holovibes::gui
  * \param exit_value Exit value of the program
  */
 void show_error_and_exit(const std::string& error_msg, const int exit_value = 1);
+
+/*! \brief Display warning on a popup
+ *
+ * \param warn_msg Message to display on the popup
+ */
+void show_warn(const std::string& warn_msg);
 } // namespace holovibes::gui

--- a/Holovibes/sources/core/holovibes.cc
+++ b/Holovibes/sources/core/holovibes.cc
@@ -85,9 +85,10 @@ void Holovibes::init_record_queue()
         LOG_DEBUG("RecordMode = Hologram");
         auto record_fd = gpu_output_queue_.load()->get_fd();
         record_fd.depth = record_fd.depth == 1 ? 2 : record_fd.depth;
-        if (!record_queue_.load())
+        if (!record_queue_.load()) {
             record_queue_ =
-                std::make_shared<Queue>(record_fd, api::get_record_buffer_size(), QueueType::RECORD_QUEUE, device);
+                std::make_shared<Queue>(record_fd, api::get_record_buffer_size(), QueueType::RECORD_QUEUE, device); 
+        }
         else
             record_queue_.load()->rebuild(record_fd,
                                           api::get_record_buffer_size(),

--- a/Holovibes/sources/gui/other/popup_error.cc
+++ b/Holovibes/sources/gui/other/popup_error.cc
@@ -9,4 +9,11 @@ void show_error_and_exit(const std::string& error_msg, const int exit_value)
     messageBox.critical(nullptr, "Internal Error", error_msg.c_str());
     exit(exit_value);
 }
+
+void show_warn(const std::string& warn_msg)
+{
+    QMessageBox messageBox;
+    messageBox.warning(nullptr, "Warning!", warn_msg.c_str());
+}
+
 } // namespace holovibes::gui

--- a/Holovibes/sources/queue.cc
+++ b/Holovibes/sources/queue.cc
@@ -37,8 +37,6 @@ Queue::Queue(const camera::FrameDescriptor& fd, const unsigned int max_size, Que
 {
     max_size_ = max_size;
 
-    std::
-
     // Check if we have enough memory to allocate the queue, otherwise reduce the size and relaunch the process.
     size_t free_memory, total_memory;
     cudaMemGetInfo(&free_memory,&total_memory);

--- a/Holovibes/sources/queue.cc
+++ b/Holovibes/sources/queue.cc
@@ -37,38 +37,48 @@ Queue::Queue(const camera::FrameDescriptor& fd, const unsigned int max_size, Que
 {
     max_size_ = max_size;
 
+    std::
+
     // Check if we have enough memory to allocate the queue, otherwise reduce the size and relaunch the process.
     size_t free_memory, total_memory;
     cudaMemGetInfo(&free_memory,&total_memory);
 
     size_t memory_to_allocate = fd.get_frame_size() * max_size_;
     bool is_size_modified = false;
+    std::string queue_string = "";
 
     if (memory_to_allocate >= free_memory)
     {
+
         switch (type)
         {
         case QueueType::INPUT_QUEUE:
             max_size_ = (free_memory - 1) / fd.get_frame_size();
             api::set_input_buffer_size(max_size_);
             is_size_modified = true;
+            queue_string = "Input Buffer";
         case QueueType::OUTPUT_QUEUE:
             max_size_ = (free_memory - 1) / fd.get_frame_size();
             api::set_output_buffer_size(max_size_);
             is_size_modified = true;
+            queue_string = "Output Buffer";
         case QueueType::RECORD_QUEUE:
             max_size_ = (free_memory - 1) / fd.get_frame_size();
             api::set_record_buffer_size(max_size_);
             is_size_modified = true;
+            queue_string = "Record Buffer";
         case QueueType::UNDEFINED:
             break;
         default:
             break;
         }
+        
         if (is_size_modified)
         {
-            LOG_WARN("Queue: not enough memory to allocate queue. Queue size was reduced to {}", max_size_);
-            // Return because when we set the buffer_size in the switch, the process is relaaunch and the ctor will be called again
+            LOG_WARN("Queue: not enough memory to allocate queue. Queue size was reduced to " + std::to_string(max_size_));
+            // For the GUI, show the warning in a window.
+            holovibes::gui::show_warn("The buffer size has been reduced to avoid memory errors. The queue is: " + queue_string + " and the new size is : " + std::to_string(max_size_));
+            // Return because when we set the buffer_size in the switch, the process is relaunched and the ctor will be called again
             return;
         }
     }

--- a/Holovibes/sources/queue.cc
+++ b/Holovibes/sources/queue.cc
@@ -36,11 +36,48 @@ Queue::Queue(const camera::FrameDescriptor& fd, const unsigned int max_size, Que
     , is_big_endian_(fd.depth >= 2 && fd.byteEndian == Endianness::BigEndian)
 {
     max_size_ = max_size;
+
+    // Check if we have enough memory to allocate the queue, otherwise reduce the size and relaunch the process.
+    size_t free_memory, total_memory;
+    cudaMemGetInfo(&free_memory,&total_memory);
+
+    size_t memory_to_allocate = fd.get_frame_size() * max_size_;
+    bool is_size_modified = false;
+
+    if (memory_to_allocate >= free_memory)
+    {
+        switch (type)
+        {
+        case QueueType::INPUT_QUEUE:
+            max_size_ = (free_memory - 1) / fd.get_frame_size();
+            api::set_input_buffer_size(max_size_);
+            is_size_modified = true;
+        case QueueType::OUTPUT_QUEUE:
+            max_size_ = (free_memory - 1) / fd.get_frame_size();
+            api::set_output_buffer_size(max_size_);
+            is_size_modified = true;
+        case QueueType::RECORD_QUEUE:
+            max_size_ = (free_memory - 1) / fd.get_frame_size();
+            api::set_record_buffer_size(max_size_);
+            is_size_modified = true;
+        case QueueType::UNDEFINED:
+            break;
+        default:
+            break;
+        }
+        if (is_size_modified)
+        {
+            LOG_WARN("Queue: not enough memory to allocate queue. Queue size was reduced to {}", max_size_);
+            // Return because when we set the buffer_size in the switch, the process is relaaunch and the ctor will be called again
+            return;
+        }
+    }
+
     if (max_size_ == 0 || !data_.resize(fd_.get_frame_size() * max_size_))
     {
         LOG_ERROR("Queue: could not allocate queue");
 
-        throw std::logic_error(std::string("Could not allocate queue (max_size: ") + std::to_string(max_size) + ")");
+        throw std::logic_error(std::string("Could not allocate queue (max_size: ") + std::to_string(max_size_) + ")");
     }
 
     // // Needed if input is embedded into a bigger square
@@ -48,6 +85,7 @@ Queue::Queue(const camera::FrameDescriptor& fd, const unsigned int max_size, Que
     //     cudaXMemset(data_.get(), 0, fd_.get_frame_size() * max_size_);
     // else
     //     std::memset(data_.get(), 0, fd_.get_frame_size() * max_size_);
+
 
     cudaXMemset(data_.get(), 0, fd_.get_frame_size() * max_size_);
 


### PR DESCRIPTION
Fixing the buffer size issue #478. Now the buffer size is automatically recalculated when too large in order to avoid to take too much memory and crash the system. A warning window inform the user about the buffer size changes when made.