### PR TITLE
fix: change path when needed in debug mode for file_on_gpu.json preset

### DIFF
--- a/Holovibes/sources/gui/windows/MainWindow.cc
+++ b/Holovibes/sources/gui/windows/MainWindow.cc
@@ -500,6 +500,11 @@ void MainWindow::load_gui()
 void MainWindow::set_preset_file_on_gpu()
 {
     std::filesystem::path dest = __PRESET_FOLDER_PATH__ / "FILE_ON_GPU.json";
+    // Check if we are in DEBUG or RELEASE
+    if (!std::filesystem::exists(dest))
+    {
+        dest = std::filesystem::path(get_exe_dir()).parent_path().parent_path() / "Preset" / "FILE_ON_GPU.json";
+    }
     api::import_buffer(dest.string());
     LOG_INFO("Preset loaded");
 }


### PR DESCRIPTION
Change the path for FILE_ON_GPU.json on debug mode.