### PR TITLE
Change default preset

### DIFF
--- a/Holovibes/sources/gui/windows/MainWindow.cc
+++ b/Holovibes/sources/gui/windows/MainWindow.cc
@@ -865,7 +865,7 @@ void MainWindow::open_light_ui()
 // Set default preset from preset.json (called from .ui)
 void MainWindow::set_preset()
 {
-    std::filesystem::path preset_directory_path(RELATIVE_PATH(__PRESET_FOLDER_PATH__ / "preset.json"));
+    std::filesystem::path preset_directory_path(RELATIVE_PATH(__PRESET_FOLDER_PATH__ / "doppler_8b_384_28.json"));
     reload_ini(preset_directory_path.string());
     LOG_INFO("Preset loaded");
 }


### PR DESCRIPTION
The default setting button now uses 'doppler_8b_384_28.json' instead of 'preset.json'