### PR TITLE
Remove date prepend on CLI

### DIFF
--- a/Holovibes/sources/thread/frame_record_worker.cc
+++ b/Holovibes/sources/thread/frame_record_worker.cc
@@ -43,14 +43,13 @@ size_t FrameRecordWorker::compute_fps_average() const
     return ret;
 }
 
-std::string append_date_to_filepath(std::string record_file_path)
+std::string prepend_R_to_filename(std::string record_file_path)
 {
     //? Do we move this to the export panel, and consider the date to be set when the path is set/on startup ?
     std::filesystem::path filePath(record_file_path);
-    std::string date = Chrono::get_current_date();
     std::string filename = filePath.filename().string();
     std::string path = filePath.parent_path().string();
-    std::filesystem::path newFilePath = path + "/" + date + "_" + filename;
+    std::filesystem::path newFilePath = path + "/" + "R_" + filename;
     return newFilePath.string();
 }
 
@@ -93,7 +92,7 @@ void FrameRecordWorker::run()
 
     try
     {
-        std::string record_file_path = append_date_to_filepath(setting<settings::RecordFilePath>());
+        std::string record_file_path = prepend_R_to_filename(setting<settings::RecordFilePath>());
 
         output_frame_file = io_files::OutputFrameFileFactory::create(record_file_path,
                                                                      record_queue_.load()->get_fd(),

--- a/Holovibes/sources/thread/frame_record_worker.cc
+++ b/Holovibes/sources/thread/frame_record_worker.cc
@@ -43,24 +43,12 @@ size_t FrameRecordWorker::compute_fps_average() const
     return ret;
 }
 
-std::string prepend_date_to_filepath(std::string record_file_path)
+std::string prepend_string_to_filepath(std::string file_path, std::string str)
 {
-    //? Do we move this to the export panel, and consider the date to be set when the path is set/on startup ?
-    std::filesystem::path filePath(record_file_path);
-    std::string date = Chrono::get_current_date();
+    std::filesystem::path filePath(file_path);
     std::string filename = filePath.filename().string();
     std::string path = filePath.parent_path().string();
-    std::filesystem::path newFilePath = path + "/" + date + "_" + filename;
-    return newFilePath.string();
-}
-
-std::string prepend_R_to_filename(std::string record_file_path)
-{
-    //? Do we move this to the export panel, and consider the date to be set when the path is set/on startup ?
-    std::filesystem::path filePath(record_file_path);
-    std::string filename = filePath.filename().string();
-    std::string path = filePath.parent_path().string();
-    std::filesystem::path newFilePath = path + "/" + "R_" + filename;
+    std::filesystem::path newFilePath = path + "/" + str + "_" + filename;
     return newFilePath.string();
 }
 
@@ -105,9 +93,10 @@ void FrameRecordWorker::run()
     {
         std::string record_file_path;
         if (Holovibes::instance().is_cli)
-            record_file_path = prepend_R_to_filename(setting<settings::RecordFilePath>());
+            record_file_path = prepend_string_to_filepath(setting<settings::RecordFilePath>(), "R");
         else
-            record_file_path = prepend_date_to_filepath(setting<settings::RecordFilePath>());
+            record_file_path =
+                prepend_string_to_filepath(setting<settings::RecordFilePath>(), Chrono::get_current_date());
 
         output_frame_file = io_files::OutputFrameFileFactory::create(record_file_path,
                                                                      record_queue_.load()->get_fd(),

--- a/Holovibes/sources/thread/frame_record_worker.cc
+++ b/Holovibes/sources/thread/frame_record_worker.cc
@@ -43,6 +43,17 @@ size_t FrameRecordWorker::compute_fps_average() const
     return ret;
 }
 
+std::string prepend_date_to_filepath(std::string record_file_path)
+{
+    //? Do we move this to the export panel, and consider the date to be set when the path is set/on startup ?
+    std::filesystem::path filePath(record_file_path);
+    std::string date = Chrono::get_current_date();
+    std::string filename = filePath.filename().string();
+    std::string path = filePath.parent_path().string();
+    std::filesystem::path newFilePath = path + "/" + date + "_" + filename;
+    return newFilePath.string();
+}
+
 std::string prepend_R_to_filename(std::string record_file_path)
 {
     //? Do we move this to the export panel, and consider the date to be set when the path is set/on startup ?
@@ -92,7 +103,11 @@ void FrameRecordWorker::run()
 
     try
     {
-        std::string record_file_path = prepend_R_to_filename(setting<settings::RecordFilePath>());
+        std::string record_file_path;
+        if (Holovibes::instance().is_cli)
+            record_file_path = prepend_R_to_filename(setting<settings::RecordFilePath>());
+        else
+            record_file_path = prepend_date_to_filepath(setting<settings::RecordFilePath>());
 
         output_frame_file = io_files::OutputFrameFileFactory::create(record_file_path,
                                                                      record_queue_.load()->get_fd(),


### PR DESCRIPTION
Removed the date prepend on output file in CLI and instead prepend "R_" to the output file to show it is an output
The original acquisition date is the only one that really matters according to Michael
Maybe Michael still wants the output date along with the "R_", in this case simply add it back in the date prepend function