### PR TITLE
opti bw area filter

### DIFF
--- a/Holovibes/assets/ui/mainwindow.ui
+++ b/Holovibes/assets/ui/mainwindow.ui
@@ -2620,22 +2620,6 @@ The range of frequencies kept is [z, z + width]</string>
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
-            <widget class="QSpinBox" name="BwAreaFilterSpinBox">
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>10000</number>
-             </property>
-             <property name="singleStep">
-              <number>1</number>
-             </property>
-             <property name="value">
-              <number>15</number>
-             </property>
-            </widget>
-           </item>
           </layout>
          </item>
          <item>
@@ -6381,28 +6365,6 @@ li.checked::marker { content: &quot;\2612&quot;; }
    </hints>
   </connection>
   <connection>
-   <sender>BwAreaFilterCheckbox</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>AnalysisPanel</receiver>
-   <slot>set_bw_area_filter(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>806</x>
-     <y>132</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>869</x>
-     <y>405</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>BwAreaFilterSpinBox</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>AnalysisPanel</receiver>
-   <slot>set_bw_area_filter_value(int)</slot>
-  </connection>
-  <connection>
    <sender>OtsuKindComboBox</sender>
    <signal>currentIndexChanged(int)</signal>
    <receiver>AnalysisPanel</receiver>
@@ -6459,6 +6421,22 @@ li.checked::marker { content: &quot;\2612&quot;; }
     <hint type="sourcelabel">
      <x>925</x>
      <y>95</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>869</x>
+     <y>405</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>BwAreaFilterCheckbox</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>AnalysisPanel</receiver>
+   <slot>set_bw_area_filter(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>806</x>
+     <y>132</y>
     </hint>
     <hint type="destinationlabel">
      <x>869</x>

--- a/Holovibes/cuda_includes/bw_area_filter.cuh
+++ b/Holovibes/cuda_includes/bw_area_filter.cuh
@@ -23,7 +23,7 @@ using uint = unsigned int;
  * \param[in] stream The CUDA stream on which to launch the operation
  */
 void get_connected_component(uint* labels_d,
-                             uint* labels_sizes_d,
+                             float* labels_sizes_d,
                              uint* linked_d,
                              uint* size_t_gpu_,
                              const float* image_d,
@@ -31,40 +31,13 @@ void get_connected_component(uint* labels_d,
                              const size_t height,
                              const cudaStream_t stream);
 
-/* useless les autres cons ils veulent seulement le plus grand */
-void get_n_max_index(uint* labels_sizes_d, size_t nb_label, uint* labels_max_d, size_t n, const cudaStream_t stream);
-
 /**
  * \brief set to 0.0f pixels who is keep, 1.0f otherwise
  *
  * \param[in out] image_d The image to process (GPU Memory)
  * \param[in] label_d The matrix who store label of each pixel (GPU Memory)
  * \param[in] size Size of the frame
- * \param[in] is_keep_d Structure use to know if the label is keep in the output (GPU Memory)
+ * \param[in] label_to_keep Label to keep
  * \param[in] stream The CUDA stream on which to launch the operation
  */
-void area_filter(float* image_d, const uint* label_d, size_t size, uint* is_keep_d, const cudaStream_t stream);
-
-/**
- * \brief transform labels_sizes_d to is_keep_d, we keep only labels from labels_max_d
- *
- * \param[out] labels_sizes_d the matrix use to store value (GPU Memory)
- * \param[in] nb_labels Number of labels
- * \param[in] labels_max_d Tab of label whe want to keep (GPU Memory)
- * \param[in] n Size of labels_max_d
- * \param[in] stream The CUDA stream on which to launch the operation
- */
-void create_is_keep_in_label_size(
-    uint* labels_sizes_d, size_t nb_labels, uint* labels_max_d, size_t n, const cudaStream_t stream);
-
-/**
- * \brief return the number of label
- *
- * \param[in] labels_sizes_d Matrix who store each label size (GPU Memory)
- * \param[in] size size of labels_sizes_d
- * \param[in out] size_t_gpu Size_t on GPU Memory use to store the result from cuda kernel
- * \param[in] stream The CUDA stream on which to launch the operation
- *
- * \return number of label
- */
-uint get_nb_label(uint* labels_sizes_d, size_t size, uint* size_t_gpu_, const cudaStream_t stream);
+void area_filter(float* image_d, const uint* label_d, size_t size, uint label_to_keep, const cudaStream_t stream);

--- a/Holovibes/cuda_sources/bw_area_filter.cu
+++ b/Holovibes/cuda_sources/bw_area_filter.cu
@@ -235,6 +235,7 @@ void get_connected_component(uint* labels_d,
     first_pass(image_d, labels_d, linked_d, labels_sizes_d, size_t_gpu_, width, height, stream);
 
     second_pass_kernel<<<blocks, threads, 0, stream>>>(labels_d, size, linked_d, labels_sizes_d);
+    cudaDeviceSynchronize();
 }
 
 __global__ void area_filter_kernel(float* image_d, const uint* label_d, size_t size, uint label_to_keep)

--- a/Holovibes/cuda_sources/bw_area_filter.cu
+++ b/Holovibes/cuda_sources/bw_area_filter.cu
@@ -25,12 +25,8 @@ __device__ void get_linked_label(uint* label, uint* linked_d)
     linked_d[pred] = *label;
 }
 
-__global__ void first_pass_kernel1(const float* image_d,
-                                   uint* labels_d,
-                                   uint* linked_d,
-                                   uint* lablels_sizes_d,
-                                   const size_t width,
-                                   const size_t height)
+__global__ void
+first_pass_kernel1(const float* image_d, uint* labels_d, uint* linked_d, const size_t width, const size_t height)
 {
     int idx = blockIdx.x * blockDim.x + threadIdx.x + 1;
     int x = (idx / width) * 2;
@@ -44,12 +40,8 @@ __global__ void first_pass_kernel1(const float* image_d,
     }
 }
 
-__device__ void check_and_update_link(uint* labels_d,
-                                      uint* linked_d,
-                                      const size_t idx,
-                                      uint* neighbors,
-                                      const uint nb_neighbors,
-                                      uint* mutex)
+__device__ void check_and_update_link(
+    uint* labels_d, uint* linked_d, const size_t idx, uint* neighbors, const uint nb_neighbors, uint* mutex)
 {
     if (nb_neighbors == 0)
     {
@@ -84,12 +76,8 @@ __device__ void check_and_update_link(uint* labels_d,
     }
 }
 
-__global__ void first_pass_kernel2(const float* image_d,
-                                   uint* labels_d,
-                                   uint* linked_d,
-                                   const size_t width,
-                                   const size_t height,
-                                   uint* mutex)
+__global__ void first_pass_kernel2(
+    const float* image_d, uint* labels_d, uint* linked_d, const size_t width, const size_t height, uint* mutex)
 {
     int idx = blockIdx.x * blockDim.x + threadIdx.x + 1;
     int x = (idx / width) * 2 + 1;
@@ -111,12 +99,8 @@ __global__ void first_pass_kernel2(const float* image_d,
     }
 }
 
-__global__ void first_pass_kernel3(const float* image_d,
-                                   uint* labels_d,
-                                   uint* linked_d,
-                                   const size_t width,
-                                   const size_t height,
-                                   uint* mutex)
+__global__ void first_pass_kernel3(
+    const float* image_d, uint* labels_d, uint* linked_d, const size_t width, const size_t height, uint* mutex)
 {
     int idx = blockIdx.x * blockDim.x + threadIdx.x + 1;
     int x = (idx / width) * 2;
@@ -138,12 +122,8 @@ __global__ void first_pass_kernel3(const float* image_d,
     }
 }
 
-__global__ void first_pass_kernel4(const float* image_d,
-                                   uint* labels_d,
-                                   uint* linked_d,
-                                   const size_t width,
-                                   const size_t height,
-                                   uint* mutex)
+__global__ void first_pass_kernel4(
+    const float* image_d, uint* labels_d, uint* linked_d, const size_t width, const size_t height, uint* mutex)
 {
     int idx = blockIdx.x * blockDim.x + threadIdx.x + 1;
     int x = (idx / width) * 2 + 1;
@@ -183,25 +163,10 @@ void first_pass(const float* image_d,
     cudaXMemset(linked_d, 0, sizeof(uint));
     cudaXMemset(size_t_gpu_, 0, sizeof(uint));
 
-    first_pass_kernel1<<<blocks, threads, 0, stream>>>(image_d, labels_d, linked_d,  width, height);
-    first_pass_kernel2<<<blocks, threads, 0, stream>>>(image_d,
-                                                       labels_d,
-                                                       linked_d,
-                                                       width,
-                                                       height,
-                                                       size_t_gpu_);
-    first_pass_kernel3<<<blocks, threads, 0, stream>>>(image_d,
-                                                       labels_d,
-                                                       linked_d,
-                                                       width,
-                                                       height,
-                                                       size_t_gpu_);
-    first_pass_kernel4<<<blocks, threads, 0, stream>>>(image_d,
-                                                       labels_d,
-                                                       linked_d,
-                                                       width,
-                                                       height,
-                                                       size_t_gpu_);
+    first_pass_kernel1<<<blocks, threads, 0, stream>>>(image_d, labels_d, linked_d, width, height);
+    first_pass_kernel2<<<blocks, threads, 0, stream>>>(image_d, labels_d, linked_d, width, height, size_t_gpu_);
+    first_pass_kernel3<<<blocks, threads, 0, stream>>>(image_d, labels_d, linked_d, width, height, size_t_gpu_);
+    first_pass_kernel4<<<blocks, threads, 0, stream>>>(image_d, labels_d, linked_d, width, height, size_t_gpu_);
 }
 
 __global__ void second_pass_kernel(uint* labels_d, size_t size, uint* linked_d, float* labels_sizes_d)
@@ -232,7 +197,7 @@ void get_connected_component(uint* labels_d,
     cudaXMemset(labels_d, 0, size * sizeof(uint));
     cudaXMemset(labels_sizes_d, 0.0f, size * sizeof(float));
 
-    first_pass(image_d, labels_d, linked_d, labels_sizes_d, size_t_gpu_, width, height, stream);
+    first_pass(image_d, labels_d, linked_d, size_t_gpu_, width, height, stream);
 
     second_pass_kernel<<<blocks, threads, 0, stream>>>(labels_d, size, linked_d, labels_sizes_d);
     cudaDeviceSynchronize();

--- a/Holovibes/cuda_sources/bw_area_filter.cu
+++ b/Holovibes/cuda_sources/bw_area_filter.cu
@@ -177,7 +177,7 @@ __global__ void second_pass_kernel(uint* labels_d, size_t size, uint* linked_d, 
         uint l = labels_d[idx];
         get_linked_label(&l, linked_d);
         labels_d[idx] = l;
-        atomicAdd(labels_sizes_d + l, 1);
+        atomicAdd(labels_sizes_d + l, 1.0f);
     }
 }
 
@@ -195,7 +195,7 @@ void get_connected_component(uint* labels_d,
     uint blocks = map_blocks_to_problem(size, threads);
 
     cudaXMemset(labels_d, 0, size * sizeof(uint));
-    cudaXMemset(labels_sizes_d, 0.0f, size * sizeof(float));
+    cudaXMemset(labels_sizes_d, 0, size * sizeof(float));
 
     first_pass(image_d, labels_d, linked_d, size_t_gpu_, width, height, stream);
 

--- a/Holovibes/includes/API.hxx
+++ b/Holovibes/includes/API.hxx
@@ -624,8 +624,6 @@ inline void set_bwareafilt_enabled(bool value)
     UPDATE_SETTING(BwareafiltEnabled, value);
     pipe_refresh();
 }
-inline int get_bwareafilt_n() { return GET_SETTING(BwareafiltN); }
-inline void set_bwareafilt_n(int value) { UPDATE_SETTING(BwareafiltN, value); }
 
 /*! \brief Getter and Setter for the Z fft shift, triggered when Z FFT Shift button is clicked on the gui. */
 inline bool get_z_fft_shift() noexcept { return GET_SETTING(ZFFTShift); }

--- a/Holovibes/includes/compute/analysis.hh
+++ b/Holovibes/includes/compute/analysis.hh
@@ -153,7 +153,7 @@ class Analysis
 
     cuda_tools::CudaUniquePtr<uint> uint_buffer_1_;
     cuda_tools::CudaUniquePtr<uint> uint_buffer_2_;
-    cuda_tools::CudaUniquePtr<uint> uint_buffer_3_;
+    cuda_tools::CudaUniquePtr<float> float_buffer_;
     cuda_tools::CudaUniquePtr<uint> uint_gpu_;
 };
 } // namespace holovibes::compute

--- a/Holovibes/includes/compute/analysis.hh
+++ b/Holovibes/includes/compute/analysis.hh
@@ -27,7 +27,6 @@
     holovibes::settings::OtsuWindowSize,           \
     holovibes::settings::OtsuLocalThreshold,       \
     holovibes::settings::BwareafiltEnabled,        \
-    holovibes::settings::BwareafiltN,        \
     holovibes::settings::ConvolutionMatrix,        \
     holovibes::settings::ImageType,                \
     holovibes::settings::TimeWindow,               \

--- a/Holovibes/includes/core/holovibes.hh
+++ b/Holovibes/includes/core/holovibes.hh
@@ -127,8 +127,7 @@
     holovibes::settings::OtsuWindowSize,                         \
     holovibes::settings::OtsuLocalThreshold,                     \
     holovibes::settings::MinMaskArea,                            \
-    holovibes::settings::BwareafiltEnabled,                      \
-    holovibes::settings::BwareafiltN                            
+    holovibes::settings::BwareafiltEnabled
 
 #define ALL_SETTINGS REALTIME_SETTINGS
 
@@ -466,8 +465,7 @@ class Holovibes
                                              settings::OtsuWindowSize{15},
                                              settings::OtsuLocalThreshold{0.15f},
                                              settings::MinMaskArea{10},
-                                             settings::BwareafiltEnabled{false},
-                                             settings::BwareafiltN{15}))
+                                             settings::BwareafiltEnabled{false}))
     {
     }
 

--- a/Holovibes/includes/core/icompute.hh
+++ b/Holovibes/includes/core/icompute.hh
@@ -46,8 +46,7 @@
     holovibes::settings::OtsuWindowSize,                         \
     holovibes::settings::OtsuLocalThreshold,                     \
     holovibes::settings::BwareafiltEnabled,                      \
-    holovibes::settings::BwareafiltN,                            \
-    holovibes::settings::RegistrationEnabled,                   \
+    holovibes::settings::RegistrationEnabled,                    \
     holovibes::settings::RawViewEnabled,                         \
     holovibes::settings::CutsViewEnabled,                        \
     holovibes::settings::RenormEnabled,                          \

--- a/Holovibes/includes/gui/windows/panels/analysis_panel.hh
+++ b/Holovibes/includes/gui/windows/panels/analysis_panel.hh
@@ -50,8 +50,6 @@ class AnalysisPanel : public Panel
     void set_otsu_local_threshold(double value);
 
     void set_bw_area_filter(bool enabled);
-    void set_bw_area_filter_value(int value);
-
     // private:
 };
 } // namespace holovibes::gui

--- a/Holovibes/includes/settings/settings.hh
+++ b/Holovibes/includes/settings/settings.hh
@@ -194,7 +194,6 @@ DECLARE_SETTING(TimeWindow, int);
 DECLARE_SETTING(VesselnessSigma, double);
 DECLARE_SETTING(MinMaskArea, int);
 DECLARE_SETTING(BwareafiltEnabled, bool);
-DECLARE_SETTING(BwareafiltN, int);
 
 DECLARE_SETTING(OtsuKind, holovibes::OtsuKind);
 DECLARE_SETTING(OtsuWindowSize, int);

--- a/Holovibes/sources/compute/analysis.cc
+++ b/Holovibes/sources/compute/analysis.cc
@@ -514,12 +514,11 @@ void Analysis::insert_bwareafilt()
                                         fd_.width,
                                         fd_.height,
                                         stream_);
-                
 
                 int maxI = -1;
                 cublasIsamax(handle, buffers_.gpu_postprocess_frame_size, labels_sizes_d, 1, &maxI);
                 if (maxI > 0)
-                    area_filter(image_d, labels_d, buffers_.gpu_postprocess_frame_size, max_label, stream_);
+                    area_filter(image_d, labels_d, buffers_.gpu_postprocess_frame_size, maxI, stream_);
             }
         });
 }

--- a/Holovibes/sources/compute/analysis.cc
+++ b/Holovibes/sources/compute/analysis.cc
@@ -517,8 +517,8 @@ void Analysis::insert_bwareafilt()
 
                 int maxI = -1;
                 cublasIsamax(handle, buffers_.gpu_postprocess_frame_size, labels_sizes_d, 1, &maxI);
-                if (maxI > 0)
-                    area_filter(image_d, labels_d, buffers_.gpu_postprocess_frame_size, maxI, stream_);
+                if (maxI - 1 > 0)
+                    area_filter(image_d, labels_d, buffers_.gpu_postprocess_frame_size, maxI - 1, stream_);
             }
         });
 }

--- a/Holovibes/sources/compute/analysis.cc
+++ b/Holovibes/sources/compute/analysis.cc
@@ -199,7 +199,7 @@ void Analysis::init()
 
     uint_buffer_1_.resize(frame_res);
     uint_buffer_2_.resize(frame_res);
-    uint_buffer_3_.resize(frame_res);
+    float_buffer_.resize(frame_res);
     uint_gpu_.resize(1);
 
     shift_corners(gaussian_kernel_buffer_.get(), batch_size, fd_.width, fd_.height, stream_);
@@ -362,7 +362,7 @@ void Analysis::dispose()
 
     uint_buffer_1_.reset(nullptr);
     uint_buffer_2_.reset(nullptr);
-    uint_buffer_3_.reset(nullptr);
+    float_buffer_.reset(nullptr);
     uint_gpu_.reset(nullptr);
 }
 
@@ -499,18 +499,12 @@ void Analysis::insert_bwareafilt()
         {
             if (setting<settings::ImageType>() == ImgType::Moments_0 && setting<settings::BwareafiltEnabled>() == true)
             {
-                size_t size = buffers_.gpu_postprocess_frame_size;
-
                 float* image_d = buffers_.gpu_postprocess_frame.get();
                 uint* labels_d = uint_buffer_1_.get();
-                uint* labels_sizes_d = uint_buffer_2_.get();
-                uint* linked_d = uint_buffer_3_.get();
+                uint* linked_d = uint_buffer_2_.get();
+                float* labels_sizes_d = float_buffer_.get();
 
-                uint nb_labels;
-                uint n = setting<settings::BwareafiltN>();
-                uint* labels_max_d = nullptr;
-
-                // shift_corners(image_d, 1, fd_.width, fd_.height, stream_);
+                cublasHandle_t& handle = cuda_tools::CublasHandle::instance();
 
                 get_connected_component(labels_d,
                                         labels_sizes_d,
@@ -520,20 +514,11 @@ void Analysis::insert_bwareafilt()
                                         fd_.width,
                                         fd_.height,
                                         stream_);
-                nb_labels = get_nb_label(labels_sizes_d, size, uint_gpu_.get(), stream_);
 
-                if (nb_labels < n)
-                    n = nb_labels;
-                if (n)
-                {
-                    cudaXMalloc(&labels_max_d, n * sizeof(uint));
-                    get_n_max_index(labels_sizes_d, size, labels_max_d, n, stream_);
-
-                    create_is_keep_in_label_size(labels_sizes_d, size, labels_max_d, n, stream_);
-
-                    area_filter(image_d, labels_d, size, labels_sizes_d, stream_);
-                    cudaXFree(labels_max_d);
-                }
+                int maxI = -1;
+                cublasIsamax(handle, buffers_.gpu_postprocess_frame_size, labels_sizes_d, 1, &maxI);
+                if (maxI > 0)
+                    area_filter(image_d, labels_d, buffers_.gpu_postprocess_frame_size, max_label, stream_);
             }
         });
 }

--- a/Holovibes/sources/compute/analysis.cc
+++ b/Holovibes/sources/compute/analysis.cc
@@ -514,6 +514,7 @@ void Analysis::insert_bwareafilt()
                                         fd_.width,
                                         fd_.height,
                                         stream_);
+                
 
                 int maxI = -1;
                 cublasIsamax(handle, buffers_.gpu_postprocess_frame_size, labels_sizes_d, 1, &maxI);

--- a/Holovibes/sources/gui/windows/panels/analysis_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/analysis_panel.cc
@@ -118,6 +118,4 @@ void AnalysisPanel::set_otsu_window_size(int value) { api::set_otsu_window_size(
 void AnalysisPanel::set_otsu_local_threshold(double value) { api::set_otsu_local_threshold((float)value); }
 
 void AnalysisPanel::set_bw_area_filter(bool enabled) { api::set_bwareafilt_enabled(enabled); }
-
-void AnalysisPanel::set_bw_area_filter_value(int value) { api::set_bwareafilt_n(value); }
 } // namespace holovibes::gui


### PR DESCRIPTION
<!> this PR is not for dev

I can't compile on my computer so if you can compile for me, it can be very kind.

So for vesselle mask bw_areafilt is call with n equal to 1 so it's useless to get n labels max, so i remove this kernel and some other kernel,

for getting the biggest connected component i use cublas, this library does not work with uint so i change labels_sizes_d (uint*) to (float*) and with cublas we get the index of the max, this index is the label to keep, and i check if this label is upper 0, because -1 is not good and 0 is background.

please ask question if needed and check if it's compile and work,

moreover i will delete frontend useless setting later.