### PR TITLE
Delete cpu record and fix typo in moments

### DIFF
--- a/Holovibes/assets/ui/advancedsettingswindow.ui
+++ b/Holovibes/assets/ui/advancedsettingswindow.ui
@@ -595,22 +595,6 @@ threshold</string>
                     </property>
                 </widget>
             </item>
-            <item row="8" column="0" colspan="2">
-                <widget class="QCheckBox" name="RecordDeviceCheckbox">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="styleSheet">
-                  <string notr="true"/>
-                 </property>
-                 <property name="text">
-                  <string>CPU Record</string>
-                 </property>
-                 <property name="checked">
-                  <bool>false</bool>
-                 </property>
-                </widget>
-               </item>
              <item row="3" column="1">
               <widget class="QDoubleSpinBox" name="ContrastLowerSpinBox">
                <property name="maximum">

--- a/Holovibes/includes/API.hh
+++ b/Holovibes/includes/API.hh
@@ -204,8 +204,6 @@ bool start_record_preconditions();
  */
 void start_record(std::function<void()> callback);
 
-void set_record_device(const Device device);
-
 /*! \brief Stops recording
  *
  * \note This functions calls the notification `record_stop` when this is done.
@@ -225,17 +223,6 @@ const std::string browse_record_output_file(std::string& std_filepath);
  * \param record_mode record mode to modify FIXME: shouldn't be stored in the wild.
  */
 void set_record_mode(const std::string& text);
-
-/*! \brief Choose if the record will be done using the GPU or the CPU. If the GPU is selected, the input queue will be
- * on the GPU, meaning that Hologramm image mode and record mode will be enabled. If the CPU is selected, the input
- * queue will be on the CPU, meaning that only Raw image mode and record mode will be enabled. The record queue will
- * always be on the CPU in CPU mode, but it can be either on GPU or CPU in GPU mode. In order for the user to vizualise
- * the hologramm up until the record, the displacement of the input queue from the GPU to the CPU is done only when the
- * record is requested ; see set_record_device() function.
- */
-void set_record_on_gpu(bool value);
-
-bool get_record_on_gpu();
 
 /*!
  * \brief Set the record queue location, between gpu and cpu

--- a/Holovibes/includes/API.hxx
+++ b/Holovibes/includes/API.hxx
@@ -160,9 +160,6 @@ inline void set_renorm_constant(unsigned int value) { UPDATE_SETTING(RenormConst
 inline float get_display_rate() { return GET_SETTING(DisplayRate); }
 inline void set_display_rate(float value) { UPDATE_SETTING(DisplayRate, value); }
 
-inline holovibes::Device get_input_queue_location() { return GET_SETTING(InputQueueLocation); }
-inline void set_input_queue_location(holovibes::Device value) { UPDATE_SETTING(InputQueueLocation, value); }
-
 inline float get_lambda() { return GET_SETTING(Lambda); }
 
 inline float get_z_distance() { return GET_SETTING(ZDistance); }
@@ -189,9 +186,6 @@ inline std::shared_ptr<Pipe> get_compute_pipe_no_throw() { return Holovibes::ins
 inline std::shared_ptr<Queue> get_gpu_output_queue() { return Holovibes::instance().get_gpu_output_queue(); };
 
 inline std::shared_ptr<BatchInputQueue> get_input_queue() { return Holovibes::instance().get_input_queue(); };
-
-inline holovibes::Device get_raw_view_queue_location() { return GET_SETTING(RawViewQueueLocation); }
-inline void set_raw_view_queue_location(holovibes::Device value) { UPDATE_SETTING(RawViewQueueLocation, value); }
 
 inline float get_reticle_scale() { return GET_SETTING(ReticleScale); }
 inline void set_reticle_scale(float value) { UPDATE_SETTING(ReticleScale, value); }
@@ -282,9 +276,6 @@ inline void set_record_frame_count(std::optional<size_t> value) { UPDATE_SETTING
 
 inline RecordMode get_record_mode() { return GET_SETTING(RecordMode); }
 inline void set_record_mode(RecordMode value) { UPDATE_SETTING(RecordMode, value); }
-
-inline bool get_record_on_gpu() { return GET_SETTING(RecordOnGPU); }
-inline void set_record_on_gpu(bool value) { UPDATE_SETTING(RecordOnGPU, value); }
 
 inline size_t get_record_frame_skip() { return GET_SETTING(RecordFrameSkip); }
 inline void set_record_frame_skip(size_t value) { UPDATE_SETTING(RecordFrameSkip, value); }

--- a/Holovibes/includes/core/holovibes.hh
+++ b/Holovibes/includes/core/holovibes.hh
@@ -112,10 +112,7 @@
     holovibes::settings::HSV,                                    \
     holovibes::settings::ZFFTShift,                              \
     holovibes::settings::RecordQueueLocation,                       \
-    holovibes::settings::RawViewQueueLocation,                      \
-    holovibes::settings::InputQueueLocation,                        \
     holovibes::settings::BenchmarkMode,                             \
-    holovibes::settings::RecordOnGPU,                               \
     holovibes::settings::FrameSkip,                                 \
     holovibes::settings::Mp4Fps,                                    \
     holovibes::settings::DataType
@@ -442,10 +439,7 @@ class Holovibes
                                              settings::HSV{CompositeHSV{}},
                                              settings::ZFFTShift{false},
                                              settings::RecordQueueLocation{Device::CPU},
-                                             settings::RawViewQueueLocation{Device::GPU},
-                                             settings::InputQueueLocation{Device::GPU},
                                              settings::BenchmarkMode{false},
-                                             settings::RecordOnGPU{true},
                                              settings::FrameSkip{0},
                                              settings::Mp4Fps{24},
                                              settings::DataType{RecordedDataType::RAW}))

--- a/Holovibes/includes/core/icompute.hh
+++ b/Holovibes/includes/core/icompute.hh
@@ -85,9 +85,7 @@
     holovibes::settings::ContrastUpperThreshold,                 \
     holovibes::settings::RenormConstant,                         \
     holovibes::settings::CutsContrastPOffset,                    \
-    holovibes::settings::RecordQueueLocation,                    \
-    holovibes::settings::RawViewQueueLocation,                   \
-    holovibes::settings::InputQueueLocation
+    holovibes::settings::RecordQueueLocation
 
 #define PIPEREFRESH_SETTINGS                                     \
     holovibes::settings::TimeStride,                             \

--- a/Holovibes/includes/settings/settings.hh
+++ b/Holovibes/includes/settings/settings.hh
@@ -132,14 +132,12 @@ DECLARE_SETTING(ChartRecordEnabled, bool);
 /*! \name Advanced Cache */
 DECLARE_SETTING(DisplayRate, float);
 DECLARE_SETTING(InputBufferSize, size_t);
-DECLARE_SETTING(InputQueueLocation, holovibes::Device);
 DECLARE_SETTING(RecordBufferSize, size_t);
 DECLARE_SETTING(ContrastLowerThreshold, float);
 DECLARE_SETTING(RawBitshift, size_t);
 DECLARE_SETTING(ContrastUpperThreshold, float);
 DECLARE_SETTING(RenormConstant, unsigned);
 DECLARE_SETTING(CutsContrastPOffset, size_t);
-DECLARE_SETTING(RecordOnGPU, bool);
 DECLARE_SETTING(BenchmarkMode, bool);
 
 /*! \name ComputeCache */
@@ -184,7 +182,6 @@ DECLARE_SETTING(HSV, holovibes::CompositeHSV);
 DECLARE_SETTING(ZFFTShift, bool);
 
 DECLARE_SETTING(RecordQueueLocation, holovibes::Device);
-DECLARE_SETTING(RawViewQueueLocation, holovibes::Device);
 
 DECLARE_SETTING(FrameSkip, uint);
 DECLARE_SETTING(Mp4Fps, uint);

--- a/Holovibes/sources/compute/fourier_transform.cc
+++ b/Holovibes/sources/compute/fourier_transform.cc
@@ -294,11 +294,14 @@ void FourierTransform::insert_moments_to_output()
             else if (setting<settings::ImageType>() == ImgType::Moments_2)
                 moment = moments_env_.moment2_buffer;
 
-            cudaXMemcpyAsync(buffers_.gpu_postprocess_frame.get(),
-                             moment,
-                             image_size,
-                             cudaMemcpyDeviceToDevice,
-                             stream_);
+            if (moment)
+            {
+                cudaXMemcpyAsync(buffers_.gpu_postprocess_frame.get(),
+                                 moment,
+                                 image_size,
+                                 cudaMemcpyDeviceToDevice,
+                                 stream_);
+            }
         });
 }
 

--- a/Holovibes/sources/core/holovibes.cc
+++ b/Holovibes/sources/core/holovibes.cc
@@ -43,12 +43,9 @@ void Holovibes::init_input_queue(const unsigned int input_queue_size)
 void Holovibes::init_input_queue(const camera::FrameDescriptor& fd, const unsigned int input_queue_size)
 {
     if (!input_queue_.load())
-        input_queue_ = std::make_shared<BatchInputQueue>(input_queue_size,
-                                                         api::get_batch_size(),
-                                                         fd,
-                                                         api::get_input_queue_location());
+        input_queue_ = std::make_shared<BatchInputQueue>(input_queue_size, api::get_batch_size(), fd);
     else
-        input_queue_.load()->rebuild(fd, input_queue_size, api::get_batch_size(), api::get_input_queue_location());
+        input_queue_.load()->rebuild(fd, input_queue_size, api::get_batch_size(), Device::GPU);
     LOG_DEBUG("Input queue allocated");
 }
 
@@ -240,10 +237,6 @@ void Holovibes::start_frame_record(const std::function<void()>& callback)
     }
 
     api::set_record_frame_count(get_setting<settings::RecordFrameCount>().value);
-
-    // if the record is on the cpu
-    if (api::get_record_on_gpu() == false)
-        api::set_record_device(Device::CPU);
 
     if (!record_queue_.load())
         init_record_queue();

--- a/Holovibes/sources/gui/windows/AdvancedSettingsWindow.cc
+++ b/Holovibes/sources/gui/windows/AdvancedSettingsWindow.cc
@@ -30,7 +30,6 @@ void AdvancedSettingsWindow::closeEvent(QCloseEvent* event) { emit closed(); }
 void AdvancedSettingsWindow::set_ui_values()
 {
     api::set_record_queue_location(ui.RecordQueueLocationCheckBox->isChecked() ? Device::GPU : Device::CPU);
-    api::set_record_on_gpu(!ui.RecordDeviceCheckbox->isChecked());
 
     api::set_file_buffer_size(static_cast<int>(ui.FileBSSpinBox->value()));
     api::set_input_buffer_size(static_cast<int>(ui.InputBSSpinBox->value()));
@@ -94,8 +93,6 @@ void AdvancedSettingsWindow::set_current_values()
     ui.CutsContrastSpinBox->setValue(api::get_cuts_contrast_p_offset());
 
     ui.RecordQueueLocationCheckBox->setChecked(api::get_record_queue_location() == Device::GPU);
-    ui.RecordQueueLocationCheckBox->setEnabled(api::get_input_queue_location() == Device::GPU);
-    ui.RecordDeviceCheckbox->setChecked(!api::get_record_on_gpu());
 
     ui.OutputNameLineEdit->setText(UserInterfaceDescriptor::instance().output_filename_.c_str());
     ui.InputFolderPathLineEdit->setText(UserInterfaceDescriptor::instance().record_output_directory_.c_str());

--- a/Holovibes/sources/gui/windows/panels/export_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/export_panel.cc
@@ -296,20 +296,8 @@ void ExportPanel::start_record()
 
     ui_->InfoPanel->set_visible_record_progress(true);
 
-    auto callback = [record_mode = api::get_record_mode(),
-                     compute_mode = api::get_compute_mode(),
-                     gpu_record = api::get_record_on_gpu(),
-                     this]()
-    {
-        parent_->synchronize_thread(
-            [=]()
-            {
-                record_finished(record_mode);
-                // if the record was in cpu mode, open the previous compute mode at the end of the record
-                if (!gpu_record)
-                    ui_->ImageRenderingPanel->set_image_mode(static_cast<int>(compute_mode));
-            });
-    };
+    auto callback = [record_mode = api::get_record_mode(), this]()
+    { parent_->synchronize_thread([=]() { record_finished(record_mode); }); };
 
     api::start_record(callback);
 }

--- a/Holovibes/sources/gui/windows/panels/image_rendering_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/image_rendering_panel.cc
@@ -42,7 +42,6 @@ void ImageRenderingPanel::on_notify()
     const bool is_raw = api::get_compute_mode() == Computation::Raw;
 
     ui_->ImageModeComboBox->setCurrentIndex(static_cast<int>(api::get_compute_mode()));
-    ui_->ImageModeComboBox->setEnabled((api::get_input_queue_location() == holovibes::Device::GPU));
 
     ui_->TimeStrideSpinBox->setEnabled(!is_raw);
 

--- a/Holovibes/sources/thread/camera_frame_read_worker.cc
+++ b/Holovibes/sources/thread/camera_frame_read_worker.cc
@@ -58,13 +58,7 @@ void CameraFrameReadWorker::run()
 void CameraFrameReadWorker::enqueue_loop(const camera::CapturedFramesDescriptor& captured_fd,
                                          const camera::FrameDescriptor& camera_fd)
 {
-    cudaMemcpyKind copy_kind;
-    bool input_queue_on_gpu = api::get_input_queue_location() == holovibes::Device::GPU;
-    if (input_queue_on_gpu) // if the input queue is on gpu
-        copy_kind = captured_fd.on_gpu ? cudaMemcpyDeviceToDevice : cudaMemcpyHostToDevice;
-    else // if it is on CPU
-        copy_kind = captured_fd.on_gpu ? cudaMemcpyDeviceToHost : cudaMemcpyHostToHost;
-
+    cudaMemcpyKind copy_kind = captured_fd.on_gpu ? cudaMemcpyDeviceToDevice : cudaMemcpyHostToDevice;
     for (unsigned i = 0; i < captured_fd.count1; ++i)
     {
         auto ptr = (uint8_t*)(captured_fd.region1) + i * camera_fd.get_frame_size();
@@ -81,8 +75,7 @@ void CameraFrameReadWorker::enqueue_loop(const camera::CapturedFramesDescriptor&
     compute_fps();
     *temperature_ = camera_->get_temperature();
 
-    if (input_queue_on_gpu)
-        input_queue_.load()->sync_current_batch();
+    input_queue_.load()->sync_current_batch();
 }
 
 } // namespace holovibes::worker

--- a/Holovibes/sources/thread/file_frame_read_worker.cc
+++ b/Holovibes/sources/thread/file_frame_read_worker.cc
@@ -272,10 +272,7 @@ void FileFrameReadWorker::enqueue_loop(size_t nb_frames_to_enqueue)
         if (stop_requested_)
             break;
 
-        input_queue_.load()->enqueue(gpu_file_frame_buffer_ + frames_enqueued * frame_size_,
-                                     api::get_input_queue_location() == holovibes::Device::GPU
-                                         ? cudaMemcpyDeviceToDevice
-                                         : cudaMemcpyDeviceToHost);
+        input_queue_.load()->enqueue(gpu_file_frame_buffer_ + frames_enqueued * frame_size_, cudaMemcpyDeviceToDevice);
 
         current_nb_frames_read_++;
         processed_frames_++;
@@ -289,11 +286,10 @@ void FileFrameReadWorker::enqueue_loop(size_t nb_frames_to_enqueue)
     //
     // With load_file_in_gpu_ == true, all the file in in the buffer,
     // so we don't have to sync
-    //
-    // If the input queue is not on the GPU no sync is needed
-    if (setting<settings::LoadFileInGPU>() == false &&
-        (api::get_input_queue_location() ==
-         holovibes::Device::GPU)) // onrestart_settings_.get<settings::LoadFileInGPU>().value == false)
+    if (setting<settings::LoadFileInGPU>())
+        return;
+
+    if (setting<settings::LoadFileInGPU>() == false)
         input_queue_.load()->sync_current_batch();
 }
 } // namespace holovibes::worker


### PR DESCRIPTION
Delete the CPU record option (michael). This imply:
- The input queue is always on GPU
- The raw view queue is always on GPU
- Delete the `InputQueueLocation`, `RawViewQueueLocation`, `RecordOnGPU`

Fix some issue with moments:
- When settings moments recording and not selecting a moment the app crash
- When in moments record but not actually recording, moments are calculated (so useless since not used after)