### PR TITLE
Added camera fps to the footer

### DIFF
--- a/Holovibes/includes/API.hxx
+++ b/Holovibes/includes/API.hxx
@@ -288,6 +288,9 @@ inline void set_chart_record_enabled(bool value) { UPDATE_SETTING(ChartRecordEna
 
 inline uint get_nb_frame_skip() { return GET_SETTING(FrameSkip); }
 inline uint get_mp4_fps() { return GET_SETTING(Mp4Fps); }
+
+inline uint get_camera_fps() { return GET_SETTING(CameraFps); }
+inline void set_camera_fps(uint value) { UPDATE_SETTING(CameraFps, value); }
 /*! \} */
 
 /*!

--- a/Holovibes/includes/core/holovibes.hh
+++ b/Holovibes/includes/core/holovibes.hh
@@ -64,7 +64,7 @@
     holovibes::settings::Filter2dEnabled,                        \
     holovibes::settings::Filter2dViewEnabled,                    \
     holovibes::settings::FftShiftEnabled,                        \
-    holovibes::settings::RegistrationEnabled,                   \
+    holovibes::settings::RegistrationEnabled,                    \
     holovibes::settings::RawViewEnabled,                         \
     holovibes::settings::CutsViewEnabled,                        \
     holovibes::settings::RenormEnabled,                          \
@@ -111,10 +111,11 @@
     holovibes::settings::RGB,                                    \
     holovibes::settings::HSV,                                    \
     holovibes::settings::ZFFTShift,                              \
-    holovibes::settings::RecordQueueLocation,                       \
-    holovibes::settings::BenchmarkMode,                             \
-    holovibes::settings::FrameSkip,                                 \
-    holovibes::settings::Mp4Fps,                                    \
+    holovibes::settings::RecordQueueLocation,                    \
+    holovibes::settings::BenchmarkMode,                          \
+    holovibes::settings::FrameSkip,                              \
+    holovibes::settings::Mp4Fps,                                 \
+    holovibes::settings::CameraFps,                              \
     holovibes::settings::DataType
 
 #define ALL_SETTINGS REALTIME_SETTINGS
@@ -442,6 +443,7 @@ class Holovibes
                                              settings::BenchmarkMode{false},
                                              settings::FrameSkip{0},
                                              settings::Mp4Fps{24},
+                                             settings::CameraFps{0},
                                              settings::DataType{RecordedDataType::RAW}))
     {
     }

--- a/Holovibes/includes/core/icompute.hh
+++ b/Holovibes/includes/core/icompute.hh
@@ -75,7 +75,8 @@
     holovibes::settings::HSV,                                    \
     holovibes::settings::ZFFTShift,                              \
     holovibes::settings::RecordFrameCount,                       \
-    holovibes::settings::RecordMode
+    holovibes::settings::RecordMode,                             \
+    holovibes::settings::CameraFps                               \
 
 
 #define ONRESTART_SETTINGS                                       \

--- a/Holovibes/includes/settings/settings.hh
+++ b/Holovibes/includes/settings/settings.hh
@@ -185,6 +185,7 @@ DECLARE_SETTING(RecordQueueLocation, holovibes::Device);
 
 DECLARE_SETTING(FrameSkip, uint);
 DECLARE_SETTING(Mp4Fps, uint);
+DECLARE_SETTING(CameraFps, uint);
 
 DECLARE_SETTING(DataType, holovibes::RecordedDataType);
 } // namespace holovibes::settings

--- a/Holovibes/sources/core/icompute.cc
+++ b/Holovibes/sources/core/icompute.cc
@@ -26,7 +26,7 @@ using camera::FrameDescriptor;
 void ICompute::fft_freqs()
 {
     uint time_transformation_size = setting<settings::TimeTransformationSize>();
-    float d = setting<settings::InputFPS>() / time_transformation_size;
+    float d = setting<settings::CameraFps>() / time_transformation_size;
 
     // We fill our buffers using CPU buffers, since CUDA buffers are not accessible
     std::unique_ptr<float[]> f0(new float[time_transformation_size]);

--- a/Holovibes/sources/io_files/input_holo_file.cc
+++ b/Holovibes/sources/io_files/input_holo_file.cc
@@ -185,10 +185,14 @@ void InputHoloFile::import_compute_settings()
         auto full_meta_data_ = json::parse("{}");
         raw_footer_.Update();
         to_json(full_meta_data_, raw_footer_);
-        full_meta_data_["compute_settings"] = full_meta_data_;
-        rec_fill_default_json(full_meta_data_, meta_data_);
+        // full_meta_data_["compute_settings"] = full_meta_data_;
+        rec_fill_default_json(full_meta_data_, meta_data_["compute_settings"]);
 
-        from_json(full_meta_data_["compute_settings"], raw_footer_);
+        from_json(full_meta_data_, raw_footer_);
+
+        auto info_json = meta_data_["info"];
+        if (info_json.contains("camera_fps"))
+            api::set_camera_fps(info_json["camera_fps"]);
     }
 
     // update GSH with the footer values

--- a/Holovibes/sources/io_files/input_holo_file.cc
+++ b/Holovibes/sources/io_files/input_holo_file.cc
@@ -191,8 +191,7 @@ void InputHoloFile::import_compute_settings()
         from_json(full_meta_data_, raw_footer_);
 
         auto info_json = meta_data_["info"];
-        if (info_json.contains("camera_fps"))
-            api::set_camera_fps(info_json["camera_fps"]);
+        api::set_camera_fps(info_json.contains("camera_fps") ? info_json["camera_fps"] : info_json["input_fps"]);
     }
 
     // update GSH with the footer values

--- a/Holovibes/sources/io_files/output_holo_file.cc
+++ b/Holovibes/sources/io_files/output_holo_file.cc
@@ -40,10 +40,12 @@ void OutputHoloFile::export_compute_settings(int input_fps, size_t contiguous)
 
     try
     {
-        auto j_fi = json{{"pixel_pitch", {{"x", api::get_pixel_size()}, {"y", api::get_pixel_size()}}},
-                         {"input_fps", input_fps},
-                         {"contiguous", contiguous},
-                         {"holovibes_version", __HOLOVIBES_VERSION__}};
+        auto j_fi =
+            json{{"pixel_pitch", {{"x", api::get_pixel_size()}, {"y", api::get_pixel_size()}}},
+                 {"input_fps", input_fps},
+                 {"camera_fps", api::get_import_type() == ImportType::Camera ? input_fps : api::get_camera_fps()},
+                 {"contiguous", contiguous},
+                 {"holovibes_version", __HOLOVIBES_VERSION__}};
         raw_footer_.Update();
         auto inter = json{};
         to_json(inter, raw_footer_);


### PR DESCRIPTION
The footer now holds the frames per second at which the camera was originally recording at when capturing the contained data.
The stored fps is the **effective** rate of capture of the camera, not the one defined by the .ini.

In the footer, the information is stored in the 'info' object, in the 'camera_fps' field.