### PR TITLE
Fix some crash related to view and more user friendly

### DIFF
--- a/Holovibes/includes/gui/windows/Filter2DWindow.hh
+++ b/Holovibes/includes/gui/windows/Filter2DWindow.hh
@@ -30,5 +30,6 @@ class Filter2DWindow : public BasicOpenGLWindow
     void paintGL() override;
 
     void focusInEvent(QFocusEvent*) override;
+    void closeEvent(QCloseEvent*) override;
 };
 } // namespace holovibes::gui

--- a/Holovibes/includes/gui/windows/MainWindow.hh
+++ b/Holovibes/includes/gui/windows/MainWindow.hh
@@ -220,5 +220,6 @@ class MainWindow : public QMainWindow
     Subscriber<bool> acquisition_finished_subscriber_;
     bool acquisition_finished_notification_received;
     Subscriber<bool> set_preset_subscriber_;
+    Subscriber<bool> notify_subscriber_;
 };
 } // namespace holovibes::gui

--- a/Holovibes/includes/gui/windows/SliceWindow.hh
+++ b/Holovibes/includes/gui/windows/SliceWindow.hh
@@ -33,5 +33,6 @@ class SliceWindow : public BasicOpenGLWindow
     void mouseMoveEvent(QMouseEvent*) override;
     void mouseReleaseEvent(QMouseEvent*) override;
     void focusInEvent(QFocusEvent*) override;
+    void closeEvent(QCloseEvent*) override;
 };
 } // namespace holovibes::gui

--- a/Holovibes/sources/compute/image_accumulation.cc
+++ b/Holovibes/sources/compute/image_accumulation.cc
@@ -30,6 +30,7 @@ void ImageAccumulation::insert_image_accumulation(float& gpu_postprocess_frame,
                            gpu_postprocess_frame_size,
                            gpu_postprocess_frame_xz,
                            gpu_postprocess_frame_yz);
+
     insert_copy_accumulation_result(setting<settings::XY>(),
                                     &gpu_postprocess_frame,
                                     setting<settings::XZ>(),
@@ -49,13 +50,7 @@ void ImageAccumulation::allocate_accumulation_queue(std::unique_ptr<Queue>& gpu_
     if (!gpu_accumulation_queue || accumulation_level != gpu_accumulation_queue->get_max_size())
     {
         gpu_accumulation_queue.reset(new Queue(fd, accumulation_level));
-
-        // accumulation queue successfully allocated
-        if (!gpu_average_frame)
-        {
-            auto frame_size = gpu_accumulation_queue->get_fd().get_frame_size();
-            gpu_average_frame.resize(frame_size);
-        }
+        gpu_average_frame.resize(gpu_accumulation_queue->get_fd().get_frame_size());
     }
 }
 
@@ -119,9 +114,16 @@ void ImageAccumulation::dispose_cuts_queue()
     LOG_FUNC();
 
     if (!(setting<settings::XZ>().output_image_accumulation > 1))
+    {
         image_acc_env_.gpu_accumulation_xz_queue.reset(nullptr);
+        image_acc_env_.gpu_float_average_xz_frame.reset(nullptr);
+    }
+
     if (!(setting<settings::YZ>().output_image_accumulation > 1))
+    {
         image_acc_env_.gpu_accumulation_yz_queue.reset(nullptr);
+        image_acc_env_.gpu_float_average_yz_frame.reset(nullptr);
+    }
 }
 
 void ImageAccumulation::clear()

--- a/Holovibes/sources/core/pipe.cc
+++ b/Holovibes/sources/core/pipe.cc
@@ -298,6 +298,7 @@ void Pipe::refresh()
         fourier_transforms_->insert_time_transformation_cuts_view(input_queue_.get_fd(),
                                                                   buffers_.gpu_postprocess_frame_xz.get(),
                                                                   buffers_.gpu_postprocess_frame_yz.get());
+
         insert_cuts_record();
 
         // Used for phase increase

--- a/Holovibes/sources/gui/windows/Filter2DWindow.cc
+++ b/Holovibes/sources/gui/windows/Filter2DWindow.cc
@@ -4,12 +4,12 @@
 #endif
 #include <cuda_gl_interop.h>
 
-#include "API.hh"
 #include "texture_update.cuh"
 #include "Filter2DWindow.hh"
 #include "MainWindow.hh"
 #include "tools.hh"
 #include "API.hh"
+#include "GUI.hh"
 
 namespace holovibes::gui
 {
@@ -188,5 +188,14 @@ void Filter2DWindow::focusInEvent(QFocusEvent* e)
 {
     QWindow::focusInEvent(e);
     api::change_window(WindowKind::Filter2D);
+    NotifierManager::notify("notify", true);
+}
+
+void Filter2DWindow::closeEvent(QCloseEvent* e)
+{
+    api::set_filter2d_view(false);
+    gui::set_filter2d_view(false, 0);
+    NotifierManager::notify("notify", true);
+    e->accept();
 }
 } // namespace holovibes::gui

--- a/Holovibes/sources/gui/windows/Filter2DWindow.cc
+++ b/Holovibes/sources/gui/windows/Filter2DWindow.cc
@@ -196,6 +196,5 @@ void Filter2DWindow::closeEvent(QCloseEvent* e)
     api::set_filter2d_view(false);
     gui::set_filter2d_view(false, 0);
     NotifierManager::notify("notify", true);
-    e->accept();
 }
 } // namespace holovibes::gui

--- a/Holovibes/sources/gui/windows/HoloWindow.cc
+++ b/Holovibes/sources/gui/windows/HoloWindow.cc
@@ -37,6 +37,7 @@ void HoloWindow::focusInEvent(QFocusEvent* e)
 {
     QOpenGLWindow::focusInEvent(e);
     api::change_window(WindowKind::XYview);
+    NotifierManager::notify("notify", true);
 }
 
 void HoloWindow::update_slice_transforms()

--- a/Holovibes/sources/gui/windows/MainWindow.cc
+++ b/Holovibes/sources/gui/windows/MainWindow.cc
@@ -34,6 +34,7 @@ namespace holovibes::gui
 {
 namespace
 {
+
 void spinBoxDecimalPointReplacement(QDoubleSpinBox* doubleSpinBox)
 {
     class DoubleValidator : public QValidator
@@ -62,8 +63,11 @@ void spinBoxDecimalPointReplacement(QDoubleSpinBox* doubleSpinBox)
     QLineEdit* lineEdit = doubleSpinBox->findChild<QLineEdit*>();
     lineEdit->setValidator(new DoubleValidator(lineEdit->validator()));
 }
+
 } // namespace
+
 #pragma region Constructor - Destructor
+
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent)
     , ui_(new Ui::MainWindow)
@@ -80,6 +84,7 @@ MainWindow::MainWindow(QWidget* parent)
                                            light_ui_->set_recordProgressBar_color(QColor(48, 143, 236), "Saving...");
                                        })
     , set_preset_subscriber_("set_preset_file_gpu", [this](bool success) { set_preset_file_on_gpu(); })
+    , notify_subscriber_("notify", [this](bool success) { notify(); })
 {
     disable_notify();
 

--- a/Holovibes/sources/gui/windows/RawWindow.cc
+++ b/Holovibes/sources/gui/windows/RawWindow.cc
@@ -9,13 +9,13 @@
 #include <QScreen>
 #include <QWheelEvent>
 
-#include "API.hh"
 #include "RawWindow.hh"
 #include "HoloWindow.hh"
 #include "cuda_memory.cuh"
 #include "common.cuh"
 #include "tools.hh"
 #include "API.hh"
+#include "GUI.hh"
 
 namespace holovibes
 {
@@ -412,6 +412,22 @@ void RawWindow::closeEvent(QCloseEvent* event)
     if (kView == KindOfView::Raw || kView == KindOfView::Hologram)
     {
         save_gui("holo window");
+    }
+
+    // If raw view closed, deactivate it and update the ui
+    if (kView == KindOfView::Raw)
+    {
+        api::set_raw_view(false);
+        gui::set_raw_view(false, 0);
+        NotifierManager::notify("notify", true);
+    }
+
+    // If lens view closed, deactivate it and update the ui
+    else if (kView == KindOfView::Lens)
+    {
+        api::set_lens_view(false);
+        gui::set_lens_view(false, 0);
+        NotifierManager::notify("notify", true);
     }
 }
 

--- a/Holovibes/sources/gui/windows/SliceWindow.cc
+++ b/Holovibes/sources/gui/windows/SliceWindow.cc
@@ -205,5 +205,6 @@ void SliceWindow::focusInEvent(QFocusEvent* e)
 {
     QWindow::focusInEvent(e);
     api::change_window(kView == KindOfView::SliceXZ ? WindowKind::XZview : WindowKind::YZview);
+    NotifierManager::notify("notify", true);
 }
 } // namespace holovibes::gui

--- a/Holovibes/sources/gui/windows/SliceWindow.cc
+++ b/Holovibes/sources/gui/windows/SliceWindow.cc
@@ -207,4 +207,19 @@ void SliceWindow::focusInEvent(QFocusEvent* e)
     api::change_window(kView == KindOfView::SliceXZ ? WindowKind::XZview : WindowKind::YZview);
     NotifierManager::notify("notify", true);
 }
+
+void SliceWindow::closeEvent(QCloseEvent* e)
+{
+    if (kView == KindOfView::SliceXZ)
+        api::set_enabled(WindowKind::XZview, false);
+    else if (kView == KindOfView::SliceYZ)
+        api::set_enabled(WindowKind::YZview, false);
+
+    if (!api::get_enabled(WindowKind::XZview) && !api::get_enabled(WindowKind::YZview))
+    {
+        api::set_3d_cuts_view(false);
+        gui::set_3d_cuts_view(false, 0);
+        NotifierManager::notify("notify", true);
+    }
+}
 } // namespace holovibes::gui

--- a/Holovibes/sources/gui/windows/panels/view_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/view_panel.cc
@@ -116,7 +116,13 @@ void ViewPanel::on_notify()
 
     // If one view gets disabled set to the standard XY view
     int index = static_cast<int>(api::get_current_window_type());
-    window_selection->setCurrentIndex(window_slection_view->isRowHidden(index) ? 0 : index);
+    if (window_slection_view->isRowHidden(index))
+    {
+        index = 0;
+        parent_->change_window(index);
+    }
+
+    window_selection->setCurrentIndex(index);
 
     // Log
     ui_->LogScaleCheckBox->setEnabled(true);


### PR DESCRIPTION
Fixed:
- Opening and closing a window and then change view related setting (contrast, accumulation, ...) keep changing on the last opened window and not the current
- Changing the time transformation size twice when 3D cuts opened crash

New:
- When focusing a window the view specific settings in the UI is for the focused window
- When closing a window, the settings in the UI will be unchecked