### PR TITLE
fix: choose file when saving + override in cli

### DIFF
--- a/Holovibes/includes/thread/chart_record_worker.hh
+++ b/Holovibes/includes/thread/chart_record_worker.hh
@@ -19,11 +19,6 @@
 
 #define ALL_SETTINGS ONRESTART_SETTINGS, REALTIME_SETTINGS
 
-namespace holovibes
-{
-std::string get_record_filename(std::string filename);
-} // namespace holovibes
-
 namespace holovibes::worker
 {
 /*! \class ChartRecordWorker

--- a/Holovibes/includes/thread/frame_record_worker.hh
+++ b/Holovibes/includes/thread/frame_record_worker.hh
@@ -37,8 +37,6 @@ namespace holovibes
 class Queue;
 class ICompute;
 class Holovibes;
-
-std::string get_record_filename(std::string filename);
 } // namespace holovibes
 
 namespace holovibes::worker
@@ -63,10 +61,6 @@ class FrameRecordWorker final : public Worker
         , onrestart_settings_(settings)
         , record_queue_(record_queue)
     {
-        // Holovibes::instance().get_cuda_streams().recorder_stream
-        std::string file_path = setting<settings::RecordFilePath>();
-        file_path = get_record_filename(file_path);
-        onrestart_settings_.update_setting(settings::RecordFilePath{file_path});
     }
 
     void run() override;

--- a/Holovibes/includes/tools/tools.hh
+++ b/Holovibes/includes/tools/tools.hh
@@ -64,12 +64,10 @@ namespace holovibes
 /*! \brief return width and height with the same ratio and the max of the two being window_size */
 void get_good_size(ushort& width, ushort& height, ushort window_size);
 
-/*! \brief Return the first not used filename available from the parameter filename as a base */
-
 /*! \brief Preprend a string to a file path and append a number if the file already exists
  *
- * \param file_path The file path to modify
- * \param prepend The string to prepend
+ * \param[in] file_path The file path to modify
+ * \param[in] prepend The string to prepend
  *
  * \return The new file path
  */

--- a/Holovibes/includes/tools/tools.hh
+++ b/Holovibes/includes/tools/tools.hh
@@ -31,6 +31,7 @@ using ulong = unsigned long;
 
 #include "logger.hh"
 #include "notifier.hh"
+#include "chrono.hh"
 
 #include <nlohmann/json.hpp>
 using json = ::nlohmann::json;
@@ -64,7 +65,15 @@ namespace holovibes
 void get_good_size(ushort& width, ushort& height, ushort window_size);
 
 /*! \brief Return the first not used filename available from the parameter filename as a base */
-std::string get_record_filename(std::string filename);
+
+/*! \brief Preprend a string to a file path and append a number if the file already exists
+ *
+ * \param file_path The file path to modify
+ * \param prepend The string to prepend
+ *
+ * \return The new file path
+ */
+std::string get_record_filename(std::string file_path, std::string prepend = Chrono::get_current_date());
 
 /*! \brief Returns the absolute path from a relative path (prepend by the execution directory) for qt */
 QString create_absolute_qt_path(const std::string& relative_path);

--- a/Holovibes/sources/gui/GUI.cc
+++ b/Holovibes/sources/gui/GUI.cc
@@ -333,8 +333,6 @@ const std::string browse_record_output_file(std::string& std_filepath)
     std::replace(parentPath.begin(), parentPath.end(), '/', '\\');
     UI.record_output_directory_ = std::move(parentPath);
     UI.output_filename_ = std::move(fileNameWithoutExt);
-    UI.record_output_directory_ = std::move(parentPath);
-    UI.output_filename_ = std::move(fileNameWithoutExt);
 
     return fileExt;
 }

--- a/Holovibes/sources/gui/windows/panels/export_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/export_panel.cc
@@ -191,14 +191,7 @@ QString ExportPanel::browse_record_output_file()
     if (filepath.isEmpty())
         return QString::fromStdString(api::get_record_file_path());
 
-    // Convert QString to std::string
-    std::string std_filepath = filepath.toStdString();
-
-    const std::string file_ext = gui::browse_record_output_file(std_filepath);
-    // Will pick the item combobox related to file_ext if it exists, else, nothing is done
-    ui_->RecordExtComboBox->setCurrentText(file_ext.c_str());
-
-    parent_->notify();
+    set_output_file_name(filepath.toStdString());
 
     return filepath;
 }

--- a/Holovibes/sources/thread/frame_record_worker.cc
+++ b/Holovibes/sources/thread/frame_record_worker.cc
@@ -43,15 +43,6 @@ size_t FrameRecordWorker::compute_fps_average() const
     return ret;
 }
 
-std::string prepend_string_to_filepath(std::string file_path, std::string str)
-{
-    std::filesystem::path filePath(file_path);
-    std::string filename = filePath.filename().string();
-    std::string path = filePath.parent_path().string();
-    std::filesystem::path newFilePath = path + "/" + str + "_" + filename;
-    return newFilePath.string();
-}
-
 void FrameRecordWorker::run()
 {
     onrestart_settings_.apply_updates();
@@ -93,10 +84,9 @@ void FrameRecordWorker::run()
     {
         std::string record_file_path;
         if (Holovibes::instance().is_cli)
-            record_file_path = prepend_string_to_filepath(setting<settings::RecordFilePath>(), "R");
+            record_file_path = get_record_filename(setting<settings::RecordFilePath>(), "R");
         else
-            record_file_path =
-                prepend_string_to_filepath(setting<settings::RecordFilePath>(), Chrono::get_current_date());
+            record_file_path = get_record_filename(setting<settings::RecordFilePath>());
 
         static std::map<RecordMode, RecordedDataType> m = {{RecordMode::RAW, RecordedDataType::RAW},
                                                            {RecordMode::HOLOGRAM, RecordedDataType::PROCESSED},

--- a/Holovibes/sources/tools/tools.cc
+++ b/Holovibes/sources/tools/tools.cc
@@ -31,42 +31,21 @@ void get_good_size(ushort& width, ushort& height, ushort window_size)
     }
 }
 
-std::string get_record_filename(std::string filename)
+std::string get_record_filename(std::string file_path, std::string prepend)
 {
-    size_t dot_index = filename.find_last_of('.');
-    if (dot_index == std::string::npos)
-        dot_index = filename.size();
+    std::filesystem::path filePath(file_path);
+    std::string filename = filePath.filename().stem().string();
+    std::string extension = filePath.extension().string();
+    std::string path = filePath.parent_path().string();
+    std::filesystem::path oldFilePath = path + "/" + prepend + "_" + filename;
+    std::filesystem::path newFilePath = oldFilePath.string() + extension;
 
-    // Make sure 2 files don't have the same name by adding _1 / _2 / _3 ... in
-    // the name
-    unsigned i = 1;
-
-    auto name_index = filename.find_last_of('\\');
-    if (name_index == std::string::npos)
+    for (int i = 1; std::filesystem::exists(newFilePath); ++i)
     {
-        // If no slash found, assume the last index before the dot is where to insert the date
-        name_index = filename.find_last_of('.') - 1;
+        newFilePath = oldFilePath.string() + "_" + std::to_string(i) + extension;
     }
 
-    auto search = filename;
-    search.insert(name_index + 1, Chrono::get_current_date() + "_");
-
-    while (std::filesystem::exists(search))
-    {
-        if (i == 1)
-        {
-            search.insert(dot_index + 7, "_1", 0, 2); // + 7 because of the date
-            ++i;
-            continue;
-        }
-        unsigned digits_nb = static_cast<unsigned int>(std::to_string(i - 1).length());
-        search.replace(dot_index + 7, digits_nb + 1, "_" + std::to_string(i));
-        ++i;
-    }
-    i--;
-    if (i == 0)
-        return filename;
-    return filename.insert(dot_index, "_" + std::to_string(i));
+    return newFilePath.string();
 }
 
 QString create_absolute_qt_path(const std::string& relative_path)


### PR DESCRIPTION
- Before the file name was not saved when choosing a file.
- When launching in cli/ps1, if a file with a R_{name} already existed, it was overwrote.