### PR TITLE
Added eye type to recorded files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 14.X.X
+
+- Added UI buttons that specify which eye is recorded, which is reflected in the file name
+
 ### 14.2.0
 
 - The UI can record again

--- a/Holovibes/assets/ui/lightui.ui
+++ b/Holovibes/assets/ui/lightui.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>139</height>
+    <height>215</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -82,128 +82,125 @@
       </item>
      </layout>
     </item>
-      <item>
-             <widget class="QGroupBox" name="ContrastCheckBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Contrast</string>
-              </property>
-              <property name="flat">
-               <bool>false</bool>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_3">
-               <property name="leftMargin">
-                <number>2</number>
-               </property>
-               <property name="topMargin">
-                <number>2</number>
-               </property>
-               <property name="rightMargin">
-                <number>2</number>
-               </property>
-               <property name="bottomMargin">
-                <number>2</number>
-               </property>
-               <property name="horizontalSpacing">
-                <number>0</number>
-               </property>
-               <property name="verticalSpacing">
-                <number>2</number>
-               </property>
-               <item row="2" column="1" rowspan="3">
-                <layout class="QHBoxLayout" name="horizontalLayout_8">
-                 <property name="spacing">
-                  <number>8</number>
-                 </property>
-                 <item>
-                  <widget class="QLabel" name="ContrastRangeLabel">
-                   <property name="enabled">
-                    <bool>true</bool>
-                   </property>
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                     <horstretch>1</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="statusTip">
-                    <string>The lower and upper limit of the contrast</string>
-                   </property>
-                   <property name="text">
-                    <string>Range</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="ContrastMinDoubleSpinBox">
-                   <property name="enabled">
-                    <bool>true</bool>
-                   </property>
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                     <horstretch>1</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="minimum">
-                    <double>-100.000000000000000</double>
-                   </property>
-                   <property name="maximum">
-                    <double>100.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.010000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="ContrastMaxDoubleSpinBox">
-                   <property name="enabled">
-                    <bool>true</bool>
-                   </property>
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                     <horstretch>1</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="minimum">
-                    <double>-100.000000000000000</double>
-                   </property>
-                   <property name="maximum">
-                    <double>100.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.010000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="AutoRefreshContrastCheckBox">
-                   <property name="text">
-                    <string>Auto</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
+    <item>
+     <widget class="QGroupBox" name="ContrastCheckBox">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="title">
+       <string>Contrast</string>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <property name="leftMargin">
+        <number>2</number>
+       </property>
+       <property name="topMargin">
+        <number>2</number>
+       </property>
+       <property name="rightMargin">
+        <number>2</number>
+       </property>
+       <property name="bottomMargin">
+        <number>2</number>
+       </property>
+       <property name="horizontalSpacing">
+        <number>0</number>
+       </property>
+       <property name="verticalSpacing">
+        <number>2</number>
+       </property>
+       <item row="2" column="1" rowspan="3">
+        <layout class="QHBoxLayout" name="horizontalLayout_8">
+         <property name="spacing">
+          <number>8</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="ContrastRangeLabel">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="statusTip">
+            <string>The lower and upper limit of the contrast</string>
+           </property>
+           <property name="text">
+            <string>Range</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="ContrastMinDoubleSpinBox">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimum">
+            <double>-100.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="ContrastMaxDoubleSpinBox">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimum">
+            <double>-100.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="AutoRefreshContrastCheckBox">
+           <property name="text">
+            <string>Auto</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+    </item>
     <item>
      <layout class="QHBoxLayout" name="outputFileSelectionLayout">
       <property name="spacing">
@@ -262,6 +259,40 @@
        <widget class="QLabel" name="fileExtensionLabel">
         <property name="text">
          <string>.holo</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <layout class="QGridLayout" name="recordedEyeGridLayout">
+      <item row="0" column="0" colspan="3">
+       <widget class="QLabel" name="RecordedEyeLabel">
+        <property name="toolTip">
+         <string>Which eye is being recorded.</string>
+        </property>
+        <property name="text">
+         <string>Eye recorded</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3" colspan="3">
+       <widget class="QPushButton" name="RecordedEyePushButton">
+        <property name="toolTip">
+         <string>Switch between left and right eye</string>
+        </property>
+        <property name="text">
+         <string>Unspecified</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="6">
+       <widget class="QPushButton" name="ResetRecordedEyePushButton">
+        <property name="toolTip">
+         <string>Cancel the eye choice and sets it back to unspecified</string>
+        </property>
+        <property name="text">
+         <string>Ø</string>
         </property>
        </widget>
       </item>
@@ -336,7 +367,6 @@
     </property>
     <addaction name="actionConfiguration_UI"/>
    </widget>
-
    <widget class="QMenu" name="menu_Camera">
     <property name="title">
      <string>&amp;Camera</string>
@@ -353,7 +383,6 @@
     <addaction name="menu_Model"/>
     <addaction name="actionSettings"/>
    </widget>
-
    <addaction name="menuOptions"/>
    <addaction name="menuView"/>
    <addaction name="menu_Camera"/>
@@ -382,7 +411,6 @@
     <string>Ctrl+P</string>
    </property>
   </action>
-
   <action name="actionNone">
    <property name="text">
     <string>None</string>
@@ -414,7 +442,6 @@
     <string>Alt+C</string>
    </property>
   </action>
-
  </widget>
  <customwidgets>
   <customwidget>
@@ -553,7 +580,6 @@
     </hint>
    </hints>
   </connection>
-
   <connection>
    <sender>ContrastCheckBox</sender>
    <signal>clicked(bool)</signal>
@@ -618,7 +644,6 @@
     </hint>
    </hints>
   </connection>
-
   <connection>
    <sender>actionNone</sender>
    <signal>triggered(bool)</signal>
@@ -699,7 +724,38 @@
     </hint>
    </hints>
   </connection>
-
+  <connection>
+   <sender>RecordedEyePushButton</sender>
+   <signal>clicked()</signal>
+   <receiver>LightUI</receiver>
+   <slot>update_recorded_eye()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>295</x>
+     <y>150</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>199</x>
+     <y>107</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ResetRecordedEyePushButton</sender>
+   <signal>clicked()</signal>
+   <receiver>LightUI</receiver>
+   <slot>reset_recorded_eye()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>351</x>
+     <y>150</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>199</x>
+     <y>107</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>start_stop_recording(bool)</slot>
@@ -708,16 +764,16 @@
   <slot>open_configuration_ui()</slot>
   <slot>set_preset()</slot>
   <slot>z_value_changed(int)</slot>
-
   <slot>set_contrast_mode(bool)</slot>
   <slot>set_contrast_min(double)</slot>
   <slot>set_contrast_max(double)</slot>
   <slot>set_contrast_auto_refresh(bool)</slot>
-
   <slot>camera_none()</slot>
   <slot>camera_phantom()</slot>
   <slot>camera_ametek_s711_coaxlink_qspf_plus()</slot>
   <slot>camera_ametek_s991_coaxlink_qspf_plus()</slot>
   <slot>configure_camera()</slot>
+  <slot>update_recorded_eye()</slot>
+  <slot>reset_recorded_eye()</slot>
  </slots>
 </ui>

--- a/Holovibes/assets/ui/lightui.ui
+++ b/Holovibes/assets/ui/lightui.ui
@@ -292,7 +292,7 @@
          <string>Cancel the eye choice and sets it back to unspecified</string>
         </property>
         <property name="text">
-         <string>Ø</string>
+         <string>X</string>
         </property>
        </widget>
       </item>

--- a/Holovibes/assets/ui/mainwindow.ui
+++ b/Holovibes/assets/ui/mainwindow.ui
@@ -2982,7 +2982,7 @@ The range of frequencies kept is [z, z + width]</string>
                  <item row="0" column="6">
                   <widget class="QPushButton" name="ResetRecordedEyePushButton">
                    <property name="text">
-                    <string>Ø</string>
+                    <string>X</string>
                    </property>
                    <property name="toolTip">
                     <string>Cancel the eye choice and sets it back to unspecified</string>

--- a/Holovibes/assets/ui/mainwindow.ui
+++ b/Holovibes/assets/ui/mainwindow.ui
@@ -472,6 +472,9 @@
              <property name="toolTip">
               <string>The boundary value</string>
              </property>
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
              <property name="showGroupSeparator" stdset="0">
               <bool>false</bool>
              </property>
@@ -483,9 +486,6 @@
              </property>
              <property name="maximum">
               <double>1000000.000000000000000</double>
-             </property>
-             <property name="readOnly">
-              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -2985,6 +2985,27 @@ The range of frequencies kept is [z, z + width]</string>
                    </property>
                    <property name="value">
                     <number>0</number>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="recordedEyeLayout">
+                 <item>
+                  <widget class="QLabel" name="RecordedEyeLabel">
+                   <property name="toolTip">
+                    <string>Which eye is being recorded.</string>
+                   </property>
+                   <property name="text">
+                    <string>Eye recorded</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="RecordedEyePushButton">
+                   <property name="text">
+                    <string>CurrentEye</string>
                    </property>
                   </widget>
                  </item>
@@ -5881,6 +5902,22 @@ li.checked::marker { content: &quot;\2612&quot;; }
     <hint type="destinationlabel">
      <x>119</x>
      <y>398</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>RecordedEyePushButton</sender>
+   <signal>clicked()</signal>
+   <receiver>ExportPanel</receiver>
+   <slot>update_recorded_eye()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>910</x>
+     <y>383</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>859</x>
+     <y>504</y>
     </hint>
    </hints>
   </connection>

--- a/Holovibes/assets/ui/mainwindow.ui
+++ b/Holovibes/assets/ui/mainwindow.ui
@@ -2985,7 +2985,7 @@ The range of frequencies kept is [z, z + width]</string>
                     <string>X</string>
                    </property>
                    <property name="toolTip">
-                    <string>Cancel the eye choice and sets it back to unspecified</string>
+                    <string>Cancel the eye choice and set it back to unspecified</string>
                    </property>
                   </widget>
                  </item>

--- a/Holovibes/assets/ui/mainwindow.ui
+++ b/Holovibes/assets/ui/mainwindow.ui
@@ -2958,6 +2958,27 @@ The range of frequencies kept is [z, z + width]</string>
                 </layout>
                </item>
                <item>
+                <layout class="QHBoxLayout" name="recordedEyeLayout">
+                 <item>
+                  <widget class="QLabel" name="RecordedEyeLabel">
+                   <property name="toolTip">
+                    <string>Which eye is being recorded.</string>
+                   </property>
+                   <property name="text">
+                    <string>Eye recorded</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="RecordedEyePushButton">
+                   <property name="text">
+                    <string>Unspecified</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
                 <layout class="QHBoxLayout" name="numberOfFramesLayout">
                  <item>
                   <widget class="QCheckBox" name="NumberOfFramesCheckBox">
@@ -2985,27 +3006,6 @@ The range of frequencies kept is [z, z + width]</string>
                    </property>
                    <property name="value">
                     <number>0</number>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="recordedEyeLayout">
-                 <item>
-                  <widget class="QLabel" name="RecordedEyeLabel">
-                   <property name="toolTip">
-                    <string>Which eye is being recorded.</string>
-                   </property>
-                   <property name="text">
-                    <string>Eye recorded</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="RecordedEyePushButton">
-                   <property name="text">
-                    <string>CurrentEye</string>
                    </property>
                   </widget>
                  </item>
@@ -3133,12 +3133,9 @@ The range of frequencies kept is [z, z + width]</string>
            </property>
            <property name="html">
             <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-hr { height: 1px; border-width: 0; }
-li.unchecked::marker { content: &quot;\2610&quot;; }
-li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Segoe UI'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2';&quot;&gt;...&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </widget>
@@ -3200,7 +3197,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
      <x>0</x>
      <y>0</y>
      <width>1283</width>
-     <height>21</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">

--- a/Holovibes/assets/ui/mainwindow.ui
+++ b/Holovibes/assets/ui/mainwindow.ui
@@ -2958,8 +2958,8 @@ The range of frequencies kept is [z, z + width]</string>
                 </layout>
                </item>
                <item>
-                <layout class="QHBoxLayout" name="recordedEyeLayout">
-                 <item>
+                <layout class="QGridLayout" name="recordedEyeGridLayout">
+                 <item row="0" column="0" colspan="3">
                   <widget class="QLabel" name="RecordedEyeLabel">
                    <property name="toolTip">
                     <string>Which eye is being recorded.</string>
@@ -2969,10 +2969,23 @@ The range of frequencies kept is [z, z + width]</string>
                    </property>
                   </widget>
                  </item>
-                 <item>
+                 <item row="0" column="3" colspan="3">
                   <widget class="QPushButton" name="RecordedEyePushButton">
                    <property name="text">
                     <string>Unspecified</string>
+                   </property>
+                   <property name="toolTip">
+                    <string>Switch between left and right eye</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="6">
+                  <widget class="QPushButton" name="ResetRecordedEyePushButton">
+                   <property name="text">
+                    <string>Ø</string>
+                   </property>
+                   <property name="toolTip">
+                    <string>Cancel the eye choice and sets it back to unspecified</string>
                    </property>
                   </widget>
                  </item>
@@ -5915,6 +5928,22 @@ p, li { white-space: pre-wrap; }
     <hint type="destinationlabel">
      <x>859</x>
      <y>504</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ResetRecordedEyePushButton</sender>
+   <signal>clicked()</signal>
+   <receiver>ExportPanel</receiver>
+   <slot>reset_recorded_eye()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>935</x>
+     <y>344</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>859</x>
+     <y>501</y>
     </hint>
    </hints>
   </connection>

--- a/Holovibes/includes/api/record_api.hh
+++ b/Holovibes/includes/api/record_api.hh
@@ -199,11 +199,10 @@ class RecordApi : public IApi
 
 #pragma region Eye
 
-    /**
+    /*!
      * \brief Get the eye that is recorded by the program
      *
-     * \return true The RIGHT eye
-     * \return false The LEFT eye
+     * \return RecordedEyeType Which eye is being recorded. Can be LEFT, RIGHT or NONE if no eye is selected
      */
     inline RecordedEyeType get_recorded_eye() const { return GET_SETTING(RecordedEye); }
 

--- a/Holovibes/includes/api/record_api.hh
+++ b/Holovibes/includes/api/record_api.hh
@@ -187,6 +187,10 @@ class RecordApi : public IApi
      */
     void set_record_mode_enum(RecordMode value) const;
 
+#pragma endregion
+
+#pragma region Eye
+
     /*!
      * \brief Gets the available extension for the given record mode
      *
@@ -211,11 +215,20 @@ class RecordApi : public IApi
     void set_recorded_eye(RecordedEyeType value) const;
 
     /**
-     * \brief Gets a string representation of the current recorded eye.
+     * \brief Gets a string representation of the current recorded eye
+     * This string is destined to be used for file purposes.
      *
      * \return std::string The stringified recorded eye, either "L" or "R", or "" for no eye
      */
-    std::string get_recorded_eye_string() const;
+    std::string get_recorded_eye_file_string() const;
+
+    /**
+     * \brief Gets a string representation of the current recorded eye
+     * This string is more explicit and should be used for display purposes.
+     *
+     * \return std::string The stringified recorded eye, either "L" or "R", or "" for no eye
+     */
+    std::string get_recorded_eye_display_string() const;
 
 #pragma endregion
 

--- a/Holovibes/includes/api/record_api.hh
+++ b/Holovibes/includes/api/record_api.hh
@@ -187,10 +187,6 @@ class RecordApi : public IApi
      */
     void set_record_mode_enum(RecordMode value) const;
 
-#pragma endregion
-
-#pragma region Eye
-
     /*!
      * \brief Gets the available extension for the given record mode
      *
@@ -198,6 +194,10 @@ class RecordApi : public IApi
      * \return std::vector<OutputFormat> The available file extensions as an enum.
      */
     std::vector<OutputFormat> get_supported_formats(RecordMode mode) const;
+
+#pragma endregion
+
+#pragma region Eye
 
     /**
      * \brief Get the eye that is recorded by the program

--- a/Holovibes/includes/api/record_api.hh
+++ b/Holovibes/includes/api/record_api.hh
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "common_api.hh"
+#include "enum_recorded_eye_type.hh"
 
 namespace holovibes::api
 {
@@ -200,21 +201,21 @@ class RecordApi : public IApi
      * \return true The RIGHT eye
      * \return false The LEFT eye
      */
-    inline bool get_recorded_eye() const { return GET_SETTING(RecordedEye); }
-
-    /**
-     * \brief Gets a string representation of the current recorded eye.
-     *
-     * \return std::string The stringified recorded eye, either "left" or "right"
-     */
-    inline std::string get_recorded_eye_string() const { return GET_SETTING(RecordedEye) ? "right" : "left"; }
+    inline RecordedEyeType get_recorded_eye() const { return GET_SETTING(RecordedEye); }
 
     /**
      * \brief Sets the eye to be recorded; this only affects how the recording is called
      *
-     * \param is_right_eye Which eye to record: True = RIGHT eye, False = LEFT eye
+     * \param value[in] Which eye to record
      */
-    void set_recorded_eye(bool is_right_eye) const;
+    void set_recorded_eye(RecordedEyeType value) const;
+
+    /**
+     * \brief Gets a string representation of the current recorded eye.
+     *
+     * \return std::string The stringified recorded eye, either "L" or "R", or "" for no eye
+     */
+    std::string get_recorded_eye_string() const;
 
 #pragma endregion
 

--- a/Holovibes/includes/api/record_api.hh
+++ b/Holovibes/includes/api/record_api.hh
@@ -206,28 +206,12 @@ class RecordApi : public IApi
      */
     inline RecordedEyeType get_recorded_eye() const { return GET_SETTING(RecordedEye); }
 
-    /**
+    /*!
      * \brief Sets the eye to be recorded; this only affects how the recording is called
      *
-     * \param value[in] Which eye to record
+     * \param[in] value Which eye to record
      */
     void set_recorded_eye(RecordedEyeType value) const;
-
-    /**
-     * \brief Gets a string representation of the current recorded eye
-     * This string is destined to be used for file purposes.
-     *
-     * \return std::string The stringified recorded eye, either "L" or "R", or "" for no eye
-     */
-    std::string get_recorded_eye_file_string() const;
-
-    /**
-     * \brief Gets a string representation of the current recorded eye
-     * This string is more explicit and should be used for display purposes.
-     *
-     * \return std::string The stringified recorded eye, either "L" or "R", or "" for no eye
-     */
-    std::string get_recorded_eye_display_string() const;
 
 #pragma endregion
 

--- a/Holovibes/includes/api/record_api.hh
+++ b/Holovibes/includes/api/record_api.hh
@@ -194,6 +194,28 @@ class RecordApi : public IApi
      */
     std::vector<OutputFormat> get_supported_formats(RecordMode mode) const;
 
+    /**
+     * \brief Get the eye that is recorded by the program
+     *
+     * \return true The RIGHT eye
+     * \return false The LEFT eye
+     */
+    inline bool get_recorded_eye() const { return GET_SETTING(RecordedEye); }
+
+    /**
+     * \brief Gets a string representation of the current recorded eye.
+     *
+     * \return std::string The stringified recorded eye, either "left" or "right"
+     */
+    inline std::string get_recorded_eye_string() const { return GET_SETTING(RecordedEye) ? "right" : "left"; }
+
+    /**
+     * \brief Sets the eye to be recorded; this only affects how the recording is called
+     *
+     * \param is_right_eye Which eye to record: True = RIGHT eye, False = LEFT eye
+     */
+    void set_recorded_eye(bool is_right_eye) const;
+
 #pragma endregion
 
 #pragma region Record

--- a/Holovibes/includes/core/holovibes.hh
+++ b/Holovibes/includes/core/holovibes.hh
@@ -24,6 +24,7 @@
 
 // Enum
 #include "enum_camera_kind.hh"
+#include "enum_recorded_eye_type.hh"
 #include "enum_record_mode.hh"
 #include "enum_import_type.hh"
 #include "enum_device.hh"
@@ -379,7 +380,7 @@ class Holovibes
                                              settings::RecordFilePath{std::string("")},
                                              settings::RecordFrameCount{std::nullopt},
                                              settings::RecordMode{RecordMode::RAW},
-                                             settings::RecordedEye{false},
+                                             settings::RecordedEye{RecordedEyeType::NONE},
                                              settings::RecordFrameOffset{0},
                                              settings::OutputBufferSize{1024},
                                              settings::ImageType{ImgType::Modulus},

--- a/Holovibes/includes/core/holovibes.hh
+++ b/Holovibes/includes/core/holovibes.hh
@@ -48,7 +48,8 @@
     holovibes::settings::RecordFilePath,                         \
     holovibes::settings::RecordFrameCount,                       \
     holovibes::settings::RecordMode,                             \
-    holovibes::settings::RecordFrameOffset,                        \
+    holovibes::settings::RecordedEye,                            \
+    holovibes::settings::RecordFrameOffset,                      \
     holovibes::settings::OutputBufferSize,                       \
     holovibes::settings::ImageType,                              \
     holovibes::settings::X,                                      \
@@ -378,6 +379,7 @@ class Holovibes
                                              settings::RecordFilePath{std::string("")},
                                              settings::RecordFrameCount{std::nullopt},
                                              settings::RecordMode{RecordMode::RAW},
+                                             settings::RecordedEye{false},
                                              settings::RecordFrameOffset{0},
                                              settings::OutputBufferSize{1024},
                                              settings::ImageType{ImgType::Modulus},

--- a/Holovibes/includes/core/icompute.hh
+++ b/Holovibes/includes/core/icompute.hh
@@ -75,7 +75,6 @@
     holovibes::settings::ZFFTShift,                              \
     holovibes::settings::RecordFrameCount,                       \
     holovibes::settings::RecordMode,                             \
-    holovibes::settings::RecordedEye,                            \
     holovibes::settings::CameraFps
 
 

--- a/Holovibes/includes/core/icompute.hh
+++ b/Holovibes/includes/core/icompute.hh
@@ -75,6 +75,7 @@
     holovibes::settings::ZFFTShift,                              \
     holovibes::settings::RecordFrameCount,                       \
     holovibes::settings::RecordMode,                             \
+    holovibes::settings::RecordedEye,                            \
     holovibes::settings::CameraFps
 
 

--- a/Holovibes/includes/enum/enum_recorded_eye_type.hh
+++ b/Holovibes/includes/enum/enum_recorded_eye_type.hh
@@ -13,6 +13,7 @@ namespace holovibes
 /*! \enum RecordMode
  *
  * \brief Enum that allows the user to specify what eye is being recorded
+ * This has no influence on computations, this only modifies a recording file's name
  *
  */
 enum class RecordedEyeType

--- a/Holovibes/includes/enum/enum_recorded_eye_type.hh
+++ b/Holovibes/includes/enum/enum_recorded_eye_type.hh
@@ -1,0 +1,33 @@
+/*! \file
+ *
+ * \brief Enum to differentiate what eye is being recorded
+ */
+#pragma once
+
+#include <map>
+#include <string>
+#include "all_struct.hh"
+
+namespace holovibes
+{
+/*! \enum RecordMode
+ *
+ * \brief Enum that allows the user to specify what eye is being recorded
+ *
+ */
+enum class RecordedEyeType
+{
+    LEFT, /*!< The left eye, adds '_L' to the end of the filename */
+    NONE, /*!< No eye; this will not affect the filename */
+    RIGHT /*!< The right eye, adds '_R' to the end of the filename */
+};
+
+// clang-format off
+SERIALIZE_JSON_ENUM(RecordedEyeType, {
+    {RecordedEyeType::LEFT, "LEFT"},
+    {RecordedEyeType::NONE, "NONE"},
+    {RecordedEyeType::RIGHT, "RIGHT"}
+})
+
+// clang-format on
+} // namespace holovibes

--- a/Holovibes/includes/gui/GUI.hh
+++ b/Holovibes/includes/gui/GUI.hh
@@ -107,6 +107,15 @@ void set_reticle_overlay_visible(bool value);
 void open_advanced_settings(
     QMainWindow* parent = nullptr, std::function<void()> callback = []() {});
 
+/*!
+ * \brief Gets a string representation of the current recorded eye
+ * This string is more explicit and should be used for display purposes.
+ *
+ * \return std::string The stringified recorded eye,
+ * either "Left" or "Right", or "Unspecified" for no eye
+ */
+std::string get_recorded_eye_display_string();
+
 /*! \brief Gets the destination of the output file
  *
  * \param[in] std_filepath the output filepath.

--- a/Holovibes/includes/gui/windows/lightui.hh
+++ b/Holovibes/includes/gui/windows/lightui.hh
@@ -200,7 +200,12 @@ class LightUI : public QMainWindow
 
     /*! \brief the Apply setting button in the UI. Load the settings file of the current camera */
     void configure_camera();
-    /*! \} */
+
+    /*! \brief Changes the recorded eye according to the current one */
+    void update_recorded_eye();
+
+    /*! \brief Sets the recorded eye to None */
+    void reset_recorded_eye();
 
   protected:
     /**

--- a/Holovibes/includes/gui/windows/lightui.hh
+++ b/Holovibes/includes/gui/windows/lightui.hh
@@ -139,9 +139,9 @@ class LightUI : public QMainWindow
      */
     void start_stop_recording(bool start);
 
-    /**
-     * @brief Slot for handling changes in Z value from the ui.
-     * @param z_distance The new Z distance value.
+    /*!
+     * \brief Slot for handling changes in Z value from the ui.
+     * \param[in] z_distance The new Z distance value.
      */
     void z_value_changed(int z_distance);
 
@@ -151,7 +151,7 @@ class LightUI : public QMainWindow
     /*!
      * \brief Enable or disable contrast
      *
-     * \param enabled
+     * \param[in] enabled
      */
     void set_contrast_mode(bool enabled);
 
@@ -211,22 +211,22 @@ class LightUI : public QMainWindow
 
   protected:
     /**
-     * @brief Overridden closeEvent handler.
-     * @param event The QCloseEvent instance.
+     * \brief Overridden closeEvent handler.
+     * \param[in] event The QCloseEvent instance.
      */
     void closeEvent(QCloseEvent* event) override;
 
   private:
-    Ui::LightUI* ui_;                                ///< Pointer to the UI instance.
-    MainWindow* main_window_;                        ///< Pointer to the MainWindow instance.
-    bool visible_;                                   ///< Boolean to track the visibility state of the UI.
-    Subscriber<bool> notify_subscriber_;             ///< Subscriber that runs the notify function and updates the UI.
-    Subscriber<RecordMode> record_start_subscriber_; ///< Subscriber for record start events.
-    Subscriber<RecordMode> record_end_subscriber_;   ///< Subscriber for record end events.
-    Subscriber<bool> record_finished_subscriber_;    ///< Subscriber for record finished events.
-    Subscriber<RecordProgressData> record_progress_subscriber_; ///< Subscriber for record progress events.
+    Ui::LightUI* ui_;                                // Pointer to the UI instance.
+    MainWindow* main_window_;                        // Pointer to the MainWindow instance.
+    bool visible_;                                   // Boolean to track the visibility state of the UI.
+    Subscriber<bool> notify_subscriber_;             // Subscriber that runs the notify function and updates the UI.
+    Subscriber<RecordMode> record_start_subscriber_; // Subscriber for record start events.
+    Subscriber<RecordMode> record_end_subscriber_;   // Subscriber for record end events.
+    Subscriber<bool> record_finished_subscriber_;    // Subscriber for record finished events.
+    Subscriber<RecordProgressData> record_progress_subscriber_; // Subscriber for record progress events.
     Subscriber<RecordBarColorData>
-        record_progress_bar_color_subscriber_; ///< Subscriber for record progress bar color events.
+        record_progress_bar_color_subscriber_; // Subscriber for record progress bar color events.
 };
 
 } // namespace holovibes::gui

--- a/Holovibes/includes/gui/windows/lightui.hh
+++ b/Holovibes/includes/gui/windows/lightui.hh
@@ -48,6 +48,8 @@ class LightUI : public QMainWindow
      */
     void showEvent(QShowEvent* event) override;
 
+    inline void on_notify(bool _) { notify(); }
+
     /*!
      * \brief Update UI elements with the right value stored in the app
      */
@@ -215,15 +217,14 @@ class LightUI : public QMainWindow
     void closeEvent(QCloseEvent* event) override;
 
   private:
-    Ui::LightUI* ui_;                                           ///< Pointer to the UI instance.
-    MainWindow* main_window_;                                   ///< Pointer to the MainWindow instance.
-    bool visible_;                                              ///< Boolean to track the visibility state of the UI.
-    Subscriber<RecordMode> record_start_subscriber_;            ///< Subscriber for record start events.
-    Subscriber<RecordMode> record_end_subscriber_;              ///< Subscriber for record end events.
-    Subscriber<bool> record_finished_subscriber_;               ///< Subscriber for record finished events.
+    Ui::LightUI* ui_;                                ///< Pointer to the UI instance.
+    MainWindow* main_window_;                        ///< Pointer to the MainWindow instance.
+    bool visible_;                                   ///< Boolean to track the visibility state of the UI.
+    Subscriber<bool> notify_subscriber_;             ///< Subscriber that runs the notify function and updates the UI.
+    Subscriber<RecordMode> record_start_subscriber_; ///< Subscriber for record start events.
+    Subscriber<RecordMode> record_end_subscriber_;   ///< Subscriber for record end events.
+    Subscriber<bool> record_finished_subscriber_;    ///< Subscriber for record finished events.
     Subscriber<RecordProgressData> record_progress_subscriber_; ///< Subscriber for record progress events.
-    Subscriber<const std::filesystem::path>
-        record_output_file_subscriber_; ///< Subscriber for record output file path events.
     Subscriber<RecordBarColorData>
         record_progress_bar_color_subscriber_; ///< Subscriber for record progress bar color events.
 };

--- a/Holovibes/includes/gui/windows/panels/export_panel.hh
+++ b/Holovibes/includes/gui/windows/panels/export_panel.hh
@@ -1,4 +1,4 @@
-/*! \file
+/*! \file export_panel.hh
  *
  * \brief File containing methods, attributes and slots related to the Export panel
  */
@@ -40,13 +40,13 @@ class ExportPanel : public Panel
 
     /*! \brief Enables or Disables number of frame restriction for recording
      *
-     * \param value true: enable, false: disable
+     * \param[in] value true: enable, false: disable
      */
     void set_nb_frames_mode(bool value);
 
     /*! \brief Modifies the record mode
      *
-     * \param index The new record mode's index in the UI. As it is the same as the enum, it is directly casted.
+     * \param[in] index The new record mode's index in the UI. As it is the same as the enum, it is directly casted.
      */
     void set_record_mode(int index);
 
@@ -55,7 +55,7 @@ class ExportPanel : public Panel
 
     /*! \brief Resets ui on record finished
      *
-     * \param record_mode The current record mode
+     * \param[in] record_mode The current record mode
      */
     void record_finished(RecordMode record_mode);
 
@@ -75,30 +75,28 @@ class ExportPanel : public Panel
     void stop_chart_display();
 
     /*!
-     * @brief Handles the update of the record frame count enabled setting checkbox.
+     * \brief Handles the update of the record frame count enabled setting checkbox.
      */
     void update_record_frame_count_enabled();
 
     /*!
-     * @brief Handles the update of the record file path setting line edit.
+     * \brief Handles the update of the record file path setting line edit.
      */
     void update_record_file_path();
 
     /*!
-     * @brief Handles the update of the record file extension setting combo box.
+     * \brief Handles the update of the record file extension setting combo box.
      */
     void update_record_file_extension(const QString& value);
 
     /*!
      * \brief Handles the update of the recorded eye button
      * Changes the current recorded eye, cycling between left and right
-     *
      */
     void update_recorded_eye();
 
     /*!
      * \brief Sets the recorded eye to None instead of left or right
-     *
      */
     void reset_recorded_eye();
 

--- a/Holovibes/includes/gui/windows/panels/export_panel.hh
+++ b/Holovibes/includes/gui/windows/panels/export_panel.hh
@@ -89,6 +89,13 @@ class ExportPanel : public Panel
      */
     void update_record_file_extension(const QString& value);
 
+    /**
+     * \brief Handles the update of the recorded eye button.
+     * Is called when the button is pressed.
+     *
+     */
+    void update_recorded_eye();
+
   private:
     int record_frame_step_ = 512;
     Subscriber<bool> start_record_subscriber_;

--- a/Holovibes/includes/gui/windows/panels/export_panel.hh
+++ b/Holovibes/includes/gui/windows/panels/export_panel.hh
@@ -90,11 +90,17 @@ class ExportPanel : public Panel
     void update_record_file_extension(const QString& value);
 
     /**
-     * \brief Handles the update of the recorded eye button.
-     * Is called when the button is pressed.
+     * \brief Handles the update of the recorded eye button
+     * Changes the current recorded eye, cycling between left and right
      *
      */
     void update_recorded_eye();
+
+    /*!
+     * \brief Sets the recorded eye to None instead of left or right
+     *
+     */
+    void reset_recorded_eye();
 
   private:
     int record_frame_step_ = 512;

--- a/Holovibes/includes/gui/windows/panels/export_panel.hh
+++ b/Holovibes/includes/gui/windows/panels/export_panel.hh
@@ -74,22 +74,22 @@ class ExportPanel : public Panel
     /*! \brief Closes Chart window */
     void stop_chart_display();
 
-    /**
+    /*!
      * @brief Handles the update of the record frame count enabled setting checkbox.
      */
     void update_record_frame_count_enabled();
 
-    /**
+    /*!
      * @brief Handles the update of the record file path setting line edit.
      */
     void update_record_file_path();
 
-    /**
+    /*!
      * @brief Handles the update of the record file extension setting combo box.
      */
     void update_record_file_extension(const QString& value);
 
-    /**
+    /*!
      * \brief Handles the update of the recorded eye button
      * Changes the current recorded eye, cycling between left and right
      *

--- a/Holovibes/includes/settings/settings.hh
+++ b/Holovibes/includes/settings/settings.hh
@@ -14,6 +14,7 @@
 #include "struct/composite_struct.hh"
 #include "enum/enum_window_kind.hh"
 #include "enum/enum_camera_kind.hh"
+#include "enum_recorded_eye_type.hh"
 #include "enum/enum_space_transformation.hh"
 #include "enum/enum_time_transformation.hh"
 #include "enum/enum_computation.hh"
@@ -73,7 +74,7 @@ DECLARE_SETTING(RecordMode, holovibes::RecordMode);
  * \brief The setting that specifies the eye that is recorded.
  * True = right eye, False = left eye
  */
-DECLARE_SETTING(RecordedEye, bool);
+DECLARE_SETTING(RecordedEye, RecordedEyeType);
 
 /*!
  * \brief The setting that specifies the number of frames to skip before

--- a/Holovibes/includes/settings/settings.hh
+++ b/Holovibes/includes/settings/settings.hh
@@ -70,6 +70,12 @@ DECLARE_SETTING(RecordFrameCount, std::optional<size_t>);
 DECLARE_SETTING(RecordMode, holovibes::RecordMode);
 
 /*!
+ * \brief The setting that specifies the eye that is recorded.
+ * True = right eye, False = left eye
+ */
+DECLARE_SETTING(RecordedEye, bool);
+
+/*!
  * \brief The setting that specifies the number of frames to skip before
  * starting the record.
  */

--- a/Holovibes/includes/settings/settings.hh
+++ b/Holovibes/includes/settings/settings.hh
@@ -71,8 +71,9 @@ DECLARE_SETTING(RecordFrameCount, std::optional<size_t>);
 DECLARE_SETTING(RecordMode, holovibes::RecordMode);
 
 /*!
- * \brief The setting that specifies the eye that is recorded.
- * True = right eye, False = left eye
+ * \brief Get the eye that is recorded by the program
+ * Can be LEFT, RIGHT or NONE if no eye is selected
+ * It only influences the name of the output files and is saved across .holo files
  */
 DECLARE_SETTING(RecordedEye, RecordedEyeType);
 

--- a/Holovibes/includes/tools/tools.hh
+++ b/Holovibes/includes/tools/tools.hh
@@ -72,7 +72,8 @@ void get_good_size(ushort& width, ushort& height, ushort window_size);
  *
  * \return The new file path
  */
-std::string get_record_filename(std::string file_path, std::string prepend = Chrono::get_current_date());
+std::string
+get_record_filename(std::string file_path, std::string append = "", std::string prepend = Chrono::get_current_date());
 
 /*! \brief Returns the absolute path from a relative path (prepend by the execution directory) for qt */
 QString create_absolute_qt_path(const std::string& relative_path);

--- a/Holovibes/sources/api/record_api.cc
+++ b/Holovibes/sources/api/record_api.cc
@@ -47,6 +47,12 @@ std::vector<OutputFormat> RecordApi::get_supported_formats(RecordMode mode) cons
     return extension_index_map.at(mode);
 }
 
+void RecordApi::set_recorded_eye(bool is_right_eye) const
+{
+    if (!is_recording())
+        UPDATE_SETTING(RecordedEye, is_right_eye);
+}
+
 #pragma endregion
 
 #pragma region Recording

--- a/Holovibes/sources/api/record_api.cc
+++ b/Holovibes/sources/api/record_api.cc
@@ -57,22 +57,6 @@ void RecordApi::set_recorded_eye(RecordedEyeType value) const
         UPDATE_SETTING(RecordedEye, value);
 }
 
-std::string RecordApi::get_recorded_eye_file_string() const
-{
-    static std::map<RecordedEyeType, std::string> eye_map{{RecordedEyeType::LEFT, "_L"},
-                                                          {RecordedEyeType::NONE, ""},
-                                                          {RecordedEyeType::RIGHT, "_R"}};
-    return eye_map[get_recorded_eye()];
-}
-
-std::string RecordApi::get_recorded_eye_display_string() const
-{
-    static std::map<RecordedEyeType, std::string> eye_map{{RecordedEyeType::LEFT, "Left"},
-                                                          {RecordedEyeType::NONE, "Unspecified"},
-                                                          {RecordedEyeType::RIGHT, "Right"}};
-    return eye_map[get_recorded_eye()];
-}
-
 #pragma endregion
 
 #pragma region Recording

--- a/Holovibes/sources/api/record_api.cc
+++ b/Holovibes/sources/api/record_api.cc
@@ -47,10 +47,18 @@ std::vector<OutputFormat> RecordApi::get_supported_formats(RecordMode mode) cons
     return extension_index_map.at(mode);
 }
 
-void RecordApi::set_recorded_eye(bool is_right_eye) const
+void RecordApi::set_recorded_eye(RecordedEyeType value) const
 {
     if (!is_recording())
-        UPDATE_SETTING(RecordedEye, is_right_eye);
+        UPDATE_SETTING(RecordedEye, value);
+}
+
+std::string RecordApi::get_recorded_eye_string() const
+{
+    static std::map<RecordedEyeType, std::string> eye_map{{RecordedEyeType::LEFT, "_L"},
+                                                          {RecordedEyeType::NONE, ""},
+                                                          {RecordedEyeType::RIGHT, "_R"}};
+    return eye_map[get_recorded_eye()];
 }
 
 #pragma endregion

--- a/Holovibes/sources/api/record_api.cc
+++ b/Holovibes/sources/api/record_api.cc
@@ -47,17 +47,29 @@ std::vector<OutputFormat> RecordApi::get_supported_formats(RecordMode mode) cons
     return extension_index_map.at(mode);
 }
 
+#pragma endregion
+
+#pragma region Eye
+
 void RecordApi::set_recorded_eye(RecordedEyeType value) const
 {
     if (!is_recording())
         UPDATE_SETTING(RecordedEye, value);
 }
 
-std::string RecordApi::get_recorded_eye_string() const
+std::string RecordApi::get_recorded_eye_file_string() const
 {
     static std::map<RecordedEyeType, std::string> eye_map{{RecordedEyeType::LEFT, "_L"},
                                                           {RecordedEyeType::NONE, ""},
                                                           {RecordedEyeType::RIGHT, "_R"}};
+    return eye_map[get_recorded_eye()];
+}
+
+std::string RecordApi::get_recorded_eye_display_string() const
+{
+    static std::map<RecordedEyeType, std::string> eye_map{{RecordedEyeType::LEFT, "Left"},
+                                                          {RecordedEyeType::NONE, "Unspecified"},
+                                                          {RecordedEyeType::RIGHT, "Right"}};
     return eye_map[get_recorded_eye()];
 }
 

--- a/Holovibes/sources/gui/GUI.cc
+++ b/Holovibes/sources/gui/GUI.cc
@@ -325,6 +325,14 @@ std::string getNameFromFilename(const std::string& filename)
         return filename; // Returning the original filename if no match is found
 }
 
+std::string get_recorded_eye_display_string()
+{
+    static std::map<RecordedEyeType, std::string> eye_map{{RecordedEyeType::LEFT, "Left"},
+                                                          {RecordedEyeType::NONE, "Unspecified"},
+                                                          {RecordedEyeType::RIGHT, "Right"}};
+    return eye_map[API.record.get_recorded_eye()];
+}
+
 const std::string browse_record_output_file(std::string& std_filepath)
 {
     // Let std::filesystem handle path normalization and system compatibility

--- a/Holovibes/sources/gui/windows/lightui.cc
+++ b/Holovibes/sources/gui/windows/lightui.cc
@@ -100,12 +100,17 @@ void LightUI::start_stop_recording(bool start)
 void LightUI::on_record_start(RecordMode record)
 {
     ui_->startButton->setText("Stop recording");
+    ui_->RecordedEyePushButton->setEnabled(false);
+    ui_->ResetRecordedEyePushButton->setEnabled(false);
     LOG_INFO("Recording started");
 }
 
 void LightUI::on_record_stop(RecordMode record)
 {
     reset_start_button();
+
+    ui_->RecordedEyePushButton->setEnabled(true);
+    ui_->ResetRecordedEyePushButton->setEnabled(true);
 
     reset_record_progress_bar();
 
@@ -164,7 +169,7 @@ void LightUI::notify()
 
     ui_->actionSettings->setEnabled(api.input.get_camera_kind() != CameraKind::NONE);
 
-    ui_->RecordedEyePushButton->setText(QString::fromStdString(API.record.get_recorded_eye_display_string()));
+    ui_->RecordedEyePushButton->setText(QString::fromStdString(gui::get_recorded_eye_display_string()));
 }
 
 void LightUI::set_contrast_mode(bool value) { API.contrast.set_contrast_enabled(value); }

--- a/Holovibes/sources/gui/windows/lightui.cc
+++ b/Holovibes/sources/gui/windows/lightui.cc
@@ -23,12 +23,11 @@ LightUI::LightUI(QWidget* parent, MainWindow* main_window)
     , ui_(new Ui::LightUI)
     , main_window_(main_window)
     , visible_(false)
+    , notify_subscriber_("notify", std::bind(&LightUI::on_notify, this, std::placeholders::_1))
     , record_start_subscriber_("record_start", std::bind(&LightUI::on_record_start, this, std::placeholders::_1))
     , record_end_subscriber_("record_stop", std::bind(&LightUI::on_record_stop, this, std::placeholders::_1))
     , record_progress_subscriber_("record_progress",
                                   std::bind(&LightUI::on_record_progress, this, std::placeholders::_1))
-    , record_output_file_subscriber_("record_output_file",
-                                     std::bind(&LightUI::actualise_record_output_file_ui, this, std::placeholders::_1))
     , record_progress_bar_color_subscriber_(
           "record_progress_bar_color", std::bind(&LightUI::on_record_progress_bar_color, this, std::placeholders::_1))
     , record_finished_subscriber_("record_finished",
@@ -53,13 +52,6 @@ void LightUI::showEvent(QShowEvent* event)
     QMainWindow::showEvent(event);
     visible_ = true;
     notify();
-}
-
-void LightUI::actualise_record_output_file_ui(const std::filesystem::path file_path)
-{
-    ui_->OutputFilePathLineEdit->setText(QString::fromStdString(file_path.parent_path().string()));
-    // remove the extension from the filename
-    ui_->OutputFileNameLineEdit->setText(QString::fromStdString(file_path.stem().string()));
 }
 
 void LightUI::z_value_changed(int z_distance)
@@ -153,6 +145,12 @@ void LightUI::notify()
 
     ui_->ZSpinBox->setValue(static_cast<int>(std::round(z_distance * 1000)));
     ui_->ZSlider->setValue(static_cast<int>(std::round(z_distance * 1000)));
+
+    // Filename
+    std::filesystem::path file_path{API.record.get_record_file_path()};
+    ui_->OutputFilePathLineEdit->setText(QString::fromStdString(file_path.parent_path().string()));
+    // remove the extension from the filename
+    ui_->OutputFileNameLineEdit->setText(QString::fromStdString(file_path.stem().string()));
 
     // Contrast
     bool pipe_loaded = api.compute.get_compute_pipe_no_throw() != nullptr;

--- a/Holovibes/sources/gui/windows/lightui.cc
+++ b/Holovibes/sources/gui/windows/lightui.cc
@@ -165,6 +165,8 @@ void LightUI::notify()
     ui_->ContrastMaxDoubleSpinBox->setValue(api.contrast.get_contrast_max());
 
     ui_->actionSettings->setEnabled(api.input.get_camera_kind() != CameraKind::NONE);
+
+    ui_->RecordedEyePushButton->setText(QString::fromStdString(API.record.get_recorded_eye_display_string()));
 }
 
 void LightUI::set_contrast_mode(bool value) { API.contrast.set_contrast_enabled(value); }
@@ -237,5 +239,18 @@ void LightUI::set_preset()
 }
 
 void LightUI::closeEvent(QCloseEvent* event) { main_window_->close(); }
+
+void LightUI::update_recorded_eye()
+{
+    API.record.set_recorded_eye(API.record.get_recorded_eye() == RecordedEyeType::LEFT ? RecordedEyeType::RIGHT
+                                                                                       : RecordedEyeType::LEFT);
+    notify();
+}
+
+void LightUI::reset_recorded_eye()
+{
+    API.record.set_recorded_eye(RecordedEyeType::NONE);
+    notify();
+}
 
 } // namespace holovibes::gui

--- a/Holovibes/sources/gui/windows/panels/export_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/export_panel.cc
@@ -128,7 +128,7 @@ void ExportPanel::on_notify()
             ceil((ui_->ImportEndIndexSpinBox->value() - ui_->ImportStartIndexSpinBox->value()) /
                  (float)ui_->TimeStrideSpinBox->value()));
 
-    ui_->RecordedEyePushButton->setText(QString::fromStdString(api_.record.get_recorded_eye_display_string()));
+    ui_->RecordedEyePushButton->setText(QString::fromStdString(gui::get_recorded_eye_display_string()));
     // Cannot disable the button because starting/stopping a recording doesn't trigger a notify
 }
 
@@ -309,7 +309,7 @@ void ExportPanel::update_record_file_path()
                                      ui_->RecordExtComboBox->currentText().toStdString());
 }
 
-/**
+/*!
  * @brief called when change output file extension
  */
 void ExportPanel::update_record_file_extension(const QString& value)

--- a/Holovibes/sources/gui/windows/panels/export_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/export_panel.cc
@@ -141,10 +141,7 @@ void ExportPanel::on_notify()
             ceil((ui_->ImportEndIndexSpinBox->value() - ui_->ImportStartIndexSpinBox->value()) /
                  (float)ui_->TimeStrideSpinBox->value()));
 
-    static std::map<RecordedEyeType, std::string> eye_map{{RecordedEyeType::LEFT, "Left"},
-                                                          {RecordedEyeType::NONE, "Unspecified"},
-                                                          {RecordedEyeType::RIGHT, "Right"}};
-    ui_->RecordedEyePushButton->setText(QString::fromStdString(eye_map[api_.record.get_recorded_eye()]));
+    ui_->RecordedEyePushButton->setText(QString::fromStdString(api_.record.get_recorded_eye_display_string()));
     // Cannot disable the button because starting/stopping a recording doesn't trigger a notify
 }
 
@@ -339,6 +336,12 @@ void ExportPanel::update_recorded_eye()
 {
     api_.record.set_recorded_eye(api_.record.get_recorded_eye() == RecordedEyeType::LEFT ? RecordedEyeType::RIGHT
                                                                                          : RecordedEyeType::LEFT);
+    on_notify();
+}
+
+void ExportPanel::reset_recorded_eye()
+{
+    api_.record.set_recorded_eye(RecordedEyeType::NONE);
     on_notify();
 }
 

--- a/Holovibes/sources/gui/windows/panels/export_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/export_panel.cc
@@ -139,6 +139,8 @@ void ExportPanel::on_notify()
         ui_->NumberOfFramesSpinBox->setValue(
             ceil((ui_->ImportEndIndexSpinBox->value() - ui_->ImportStartIndexSpinBox->value()) /
                  (float)ui_->TimeStrideSpinBox->value()));
+
+    ui_->RecordedEyePushButton->setText(api_.record.get_recorded_eye() ? "Right" : "Left");
 }
 
 void ExportPanel::set_record_frame_step(int step)
@@ -325,4 +327,12 @@ void ExportPanel::update_record_file_extension(const QString& value)
     std::string ext = value.toStdString();
     api_.record.set_record_file_path(path + ext);
 }
+
+void ExportPanel::update_recorded_eye()
+{
+    LOG_WARN("Update recorded eye");
+    api_.record.set_recorded_eye(!api_.record.get_recorded_eye());
+    on_notify();
+}
+
 } // namespace holovibes::gui

--- a/Holovibes/sources/gui/windows/panels/export_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/export_panel.cc
@@ -1,4 +1,4 @@
-/*! \file
+/*! \file export_panel.cc
  *
  */
 
@@ -310,7 +310,7 @@ void ExportPanel::update_record_file_path()
 }
 
 /*!
- * @brief called when change output file extension
+ * \brief called when change output file extension
  */
 void ExportPanel::update_record_file_extension(const QString& value)
 {

--- a/Holovibes/sources/gui/windows/panels/export_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/export_panel.cc
@@ -27,21 +27,10 @@ ExportPanel::ExportPanel(QWidget* parent)
 
 ExportPanel::~ExportPanel() {}
 
-/*
- * \brief Small helper function NOT IN THE CLASS to update the record output file path in the UI.
- * Exists to avoid code duplication and to centralise the Notifier name 'record_output_file'.
- */
-void actualise_record_output_file_ui(const std::filesystem::path file_path)
-{
-    NotifierManager::notify<std::filesystem::path>("record_output_file", file_path);
-}
-
 void ExportPanel::init()
 {
     ui_->NumberOfFramesSpinBox->setSingleStep(record_frame_step_);
     set_record_mode(static_cast<int>(RecordMode::RAW)); // Not great but it works
-
-    actualise_record_output_file_ui(std::filesystem::path(ui_->OutputFilePathLineEdit->text().toStdString()));
 }
 
 void ExportPanel::on_notify()
@@ -124,8 +113,6 @@ void ExportPanel::on_notify()
             .string();
     path_line_edit->insert(record_output_path.c_str());
     path_line_edit->setToolTip(record_output_path.c_str());
-
-    actualise_record_output_file_ui(record_output_path);
 
     // Number of frames
     if (api_.record.get_record_frame_count().has_value())

--- a/Holovibes/sources/io/input_file/input_holo_file.cc
+++ b/Holovibes/sources/io/input_file/input_holo_file.cc
@@ -193,6 +193,8 @@ void InputHoloFile::import_compute_settings()
 
         auto info_json = meta_data_["info"];
         api.input.set_camera_fps(info_json.contains("camera_fps") ? info_json["camera_fps"] : info_json["input_fps"]);
+        if (info_json.contains("eye_type"))
+            api.record.set_recorded_eye(static_cast<RecordedEyeType>(info_json["eye_type"]));
     }
 
     // update GSH with the footer values

--- a/Holovibes/sources/io/output_file/output_holo_file.cc
+++ b/Holovibes/sources/io/output_file/output_holo_file.cc
@@ -45,6 +45,7 @@ void OutputHoloFile::export_compute_settings(int input_fps, size_t contiguous)
             {"pixel_pitch", {{"x", api.input.get_pixel_size()}, {"y", api.input.get_pixel_size()}}},
             {"input_fps", input_fps},
             {"camera_fps", api.input.get_import_type() == ImportType::Camera ? input_fps : api.input.get_camera_fps()},
+            {"eye_type", api.record.get_recorded_eye()},
             {"contiguous", contiguous},
             {"holovibes_version", __HOLOVIBES_VERSION__}};
         raw_footer_.Update();

--- a/Holovibes/sources/thread/frame_record_worker.cc
+++ b/Holovibes/sources/thread/frame_record_worker.cc
@@ -82,11 +82,16 @@ void FrameRecordWorker::run()
 
     try
     {
+        static std::map<RecordedEyeType, std::string> eye_map{{RecordedEyeType::LEFT, "_L"},
+                                                              {RecordedEyeType::NONE, ""},
+                                                              {RecordedEyeType::RIGHT, "_R"}};
+        std::string eye_string = eye_map[API.record.get_recorded_eye()];
+
         std::string record_file_path;
         if (Holovibes::instance().is_cli)
-            record_file_path = get_record_filename(setting<settings::RecordFilePath>(), "R");
+            record_file_path = get_record_filename(setting<settings::RecordFilePath>(), eye_string, "R");
         else
-            record_file_path = get_record_filename(setting<settings::RecordFilePath>());
+            record_file_path = get_record_filename(setting<settings::RecordFilePath>(), eye_string);
 
         static std::map<RecordMode, RecordedDataType> m = {{RecordMode::RAW, RecordedDataType::RAW},
                                                            {RecordMode::HOLOGRAM, RecordedDataType::PROCESSED},

--- a/Holovibes/sources/tools/tools.cc
+++ b/Holovibes/sources/tools/tools.cc
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <Windows.h>
 
+#include "API.hh"
 #include "chrono.hh"
 #include "logger.hh"
 #include "tools.hh"
@@ -37,7 +38,8 @@ std::string get_record_filename(std::string file_path, std::string prepend)
     std::string filename = filePath.filename().stem().string();
     std::string extension = filePath.extension().string();
     std::string path = filePath.parent_path().string();
-    std::filesystem::path oldFilePath = path + "/" + prepend + "_" + filename;
+    std::string eye = API.record.get_recorded_eye_string();
+    std::filesystem::path oldFilePath = path + "/" + prepend + "_" + filename + "_" + eye;
     std::filesystem::path newFilePath = oldFilePath.string() + extension;
 
     for (int i = 1; std::filesystem::exists(newFilePath); ++i)

--- a/Holovibes/sources/tools/tools.cc
+++ b/Holovibes/sources/tools/tools.cc
@@ -39,7 +39,7 @@ std::string get_record_filename(std::string file_path, std::string prepend)
     std::string extension = filePath.extension().string();
     std::string path = filePath.parent_path().string();
     std::string eye = API.record.get_recorded_eye_string();
-    std::filesystem::path oldFilePath = path + "/" + prepend + "_" + filename + "_" + eye;
+    std::filesystem::path oldFilePath = path + "/" + prepend + "_" + filename + eye;
     std::filesystem::path newFilePath = oldFilePath.string() + extension;
 
     for (int i = 1; std::filesystem::exists(newFilePath); ++i)

--- a/Holovibes/sources/tools/tools.cc
+++ b/Holovibes/sources/tools/tools.cc
@@ -32,14 +32,13 @@ void get_good_size(ushort& width, ushort& height, ushort window_size)
     }
 }
 
-std::string get_record_filename(std::string file_path, std::string prepend)
+std::string get_record_filename(std::string file_path, std::string append, std::string prepend)
 {
     std::filesystem::path filePath(file_path);
     std::string filename = filePath.filename().stem().string();
     std::string extension = filePath.extension().string();
     std::string path = filePath.parent_path().string();
-    std::string eye = API.record.get_recorded_eye_file_string();
-    std::filesystem::path oldFilePath = path + "/" + prepend + "_" + filename + eye;
+    std::filesystem::path oldFilePath = path + "/" + prepend + "_" + filename + append;
     std::filesystem::path newFilePath = oldFilePath.string() + extension;
 
     for (int i = 1; std::filesystem::exists(newFilePath); ++i)

--- a/Holovibes/sources/tools/tools.cc
+++ b/Holovibes/sources/tools/tools.cc
@@ -38,7 +38,7 @@ std::string get_record_filename(std::string file_path, std::string prepend)
     std::string filename = filePath.filename().stem().string();
     std::string extension = filePath.extension().string();
     std::string path = filePath.parent_path().string();
-    std::string eye = API.record.get_recorded_eye_string();
+    std::string eye = API.record.get_recorded_eye_file_string();
     std::filesystem::path oldFilePath = path + "/" + prepend + "_" + filename + eye;
     std::filesystem::path newFilePath = oldFilePath.string() + extension;
 


### PR DESCRIPTION
A new button has appeared in the UI in the export panel. It allows the user to specify which eye is being recorded, which is reflected in recorded files' names. The button is initially in an 'Unspefied' state, and clicking on it cycles between left and right eye.

The format is: `prefix` + `_filename` + `_L or _R or nothing`, where `prefix` is either the date or `R` depending if the recording is made in the UI or in CLI.

There is also another small button next to it labeled `X` that resets the button back to 'Unspecified'.

Both of these buttons are also present in the light UI.