### PR TITLE
Load file in ram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### 14.X.X
 
-- Added a 'Load file in RAM' checkbox in the Import panel
+- Changed the UI option 'Load file in GPU' to a drop-down menu and renamed it to 'Load file in GPU VRAM'
+- Added an option 'Load file in CPU RAM' in that drop-down
 
 ### 14.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 14.X.X
+
+- Added a 'Load file in RAM' checkbox in the Import panel
+
 ### 14.2.0
 
 - The UI can record again

--- a/Holovibes/assets/ui/mainwindow.ui
+++ b/Holovibes/assets/ui/mainwindow.ui
@@ -472,6 +472,9 @@
              <property name="toolTip">
               <string>The boundary value</string>
              </property>
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
              <property name="showGroupSeparator" stdset="0">
               <bool>false</bool>
              </property>
@@ -483,9 +486,6 @@
              </property>
              <property name="maximum">
               <double>1000000.000000000000000</double>
-             </property>
-             <property name="readOnly">
-              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -2666,6 +2666,22 @@ The range of frequencies kept is [z, z + width]</string>
              </widget>
             </item>
             <item>
+             <widget class="QCheckBox" name="LoadFileInRamCheckBox">
+              <property name="toolTip">
+               <string>Allows much higher FPS. Requires high RAM.</string>
+              </property>
+              <property name="layoutDirection">
+               <enum>Qt::LeftToRight</enum>
+              </property>
+              <property name="locale">
+               <locale language="French" country="France"/>
+              </property>
+              <property name="text">
+               <string>Load File In RAM</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <layout class="QHBoxLayout" name="horizontalLayout_27">
               <item>
                <widget class="QPushButton" name="ImportStartPushButton">
@@ -3112,12 +3128,9 @@ The range of frequencies kept is [z, z + width]</string>
            </property>
            <property name="html">
             <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-hr { height: 1px; border-width: 0; }
-li.unchecked::marker { content: &quot;\2610&quot;; }
-li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Segoe UI'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2';&quot;&gt;...&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </widget>
@@ -3179,7 +3192,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
      <x>0</x>
      <y>0</y>
      <width>1283</width>
-     <height>21</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -5774,9 +5787,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
   </connection>
   <connection>
    <sender>LoadFileInGpuCheckBox</sender>
-   <signal>stateChanged()</signal>
+   <signal>toggled(bool)</signal>
    <receiver>ImportPanel</receiver>
-   <slot>update_load_file_in_gpu()</slot>
+   <slot>update_load_file_in_gpu(bool)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>
@@ -5881,6 +5894,22 @@ li.checked::marker { content: &quot;\2612&quot;; }
     <hint type="destinationlabel">
      <x>119</x>
      <y>398</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>LoadFileInRamCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>ImportPanel</receiver>
+   <slot>update_load_file_in_ram(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>859</x>
+     <y>191</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>859</x>
+     <y>136</y>
     </hint>
    </hints>
   </connection>

--- a/Holovibes/assets/ui/mainwindow.ui
+++ b/Holovibes/assets/ui/mainwindow.ui
@@ -2650,35 +2650,22 @@ The range of frequencies kept is [z, z + width]</string>
              </layout>
             </item>
             <item>
-             <widget class="QCheckBox" name="LoadFileInGpuCheckBox">
-              <property name="toolTip">
-               <string>Allows much higher FPS. Requires high GPU DRAM.</string>
-              </property>
-              <property name="layoutDirection">
-               <enum>Qt::LeftToRight</enum>
-              </property>
-              <property name="locale">
-               <locale language="French" country="France"/>
-              </property>
-              <property name="text">
-               <string>Load File In GPU</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="LoadFileInRamCheckBox">
-              <property name="toolTip">
-               <string>Allows much higher FPS. Requires high RAM.</string>
-              </property>
-              <property name="layoutDirection">
-               <enum>Qt::LeftToRight</enum>
-              </property>
-              <property name="locale">
-               <locale language="French" country="France"/>
-              </property>
-              <property name="text">
-               <string>Load File In RAM</string>
-              </property>
+             <widget class="QComboBox" name="FileLoadKindComboBox">
+              <item>
+               <property name="text">
+                <string>Regular access</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Load in GPU VRAM</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Load in CPU RAM</string>
+               </property>
+              </item>
              </widget>
             </item>
             <item>
@@ -5786,22 +5773,6 @@ p, li { white-space: pre-wrap; }
    </hints>
   </connection>
   <connection>
-   <sender>LoadFileInGpuCheckBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>ImportPanel</receiver>
-   <slot>update_load_file_in_gpu(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>ImportInputFpsSpinBox</sender>
    <signal>editingFinished()</signal>
    <receiver>ImportPanel</receiver>
@@ -5898,18 +5869,18 @@ p, li { white-space: pre-wrap; }
    </hints>
   </connection>
   <connection>
-   <sender>LoadFileInRamCheckBox</sender>
-   <signal>toggled(bool)</signal>
+   <sender>FileLoadKindComboBox</sender>
+   <signal>currentIndexChanged(int)</signal>
    <receiver>ImportPanel</receiver>
-   <slot>update_load_file_in_ram(bool)</slot>
+   <slot>update_file_load_kind(int)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>859</x>
-     <y>191</y>
+     <y>216</y>
     </hint>
     <hint type="destinationlabel">
      <x>859</x>
-     <y>136</y>
+     <y>149</y>
     </hint>
    </hints>
   </connection>

--- a/Holovibes/includes/api/input_api.hh
+++ b/Holovibes/includes/api/input_api.hh
@@ -111,7 +111,7 @@ class InputApi : public IApi
     inline void set_load_file_in_gpu(bool value) const { UPDATE_SETTING(LoadFileInGPU, value); }
 
     /*! \brief Return whether the full file will be loaded in the CPU memory (RAM) or not. It's used similarly to
-     * LoadFileInGPU but this allows for more GPU memory space available, as RAM is less used than GPU memory.
+     * LoadFileInGPU but this allows for more GPU memory space available, albeit for slightly longer operations.
      *
      * \return bool true if the full file will be loaded in the RAM
      */

--- a/Holovibes/includes/api/input_api.hh
+++ b/Holovibes/includes/api/input_api.hh
@@ -96,33 +96,21 @@ class InputApi : public IApi
      */
     inline void set_input_file_path(std::string value) const { UPDATE_SETTING(InputFilePath, value); }
 
-    /*! \brief Return whether the full file will be loaded in the GPU memory or not. It's used to reduce memory transfer
-     * between RAM and VRAM but it will increase GPU load.
+    /*! \brief Get how the file is currently being read
      *
-     * \return bool true if the full file will be loaded in the GPU memory
+     * \return FileLoadKind The current way that files are read
+     *
+     * \see FileLoadKind More explanations here
      */
-    inline bool get_load_file_in_gpu() const { return GET_SETTING(LoadFileInGPU); }
+    inline FileLoadKind get_file_load_kind() const { return GET_SETTING(FileLoadKind); }
 
-    /*! \brief Set whether the full file will be loaded in the GPU memory or not. It's used to reduce memory transfer
-     * between RAM and VRAM but it will increase GPU load.
+    /*! \brief Set how the files should be read
      *
-     * \param[in] value true if the full file will be loaded in the GPU memory
-     */
-    inline void set_load_file_in_gpu(bool value) const { UPDATE_SETTING(LoadFileInGPU, value); }
-
-    /*! \brief Return whether the full file will be loaded in the CPU memory (RAM) or not. It's used similarly to
-     * LoadFileInGPU but this allows for more GPU memory space available, albeit for slightly longer operations.
+     * \param[in] value The new way that files should be read
      *
-     * \return bool true if the full file will be loaded in the RAM
+     * \see FileLoadKind More explanations here
      */
-    inline bool get_load_file_in_RAM() const { return GET_SETTING(LoadFileInRAM); }
-
-    /*! \brief Set whether the full file will be loaded in the CPU memory (RAM) or not. It's used similarly to
-     * LoadFileInGPU but this allows for more GPU memory space available, as RAM is less used than GPU memory.
-     *
-     * \param[in] value true if the full file will be loaded in the RAM
-     */
-    inline void set_load_file_in_ram(bool value) const { UPDATE_SETTING(LoadFileInRAM, value); }
+    inline void set_file_load_kind(FileLoadKind value) const { UPDATE_SETTING(FileLoadKind, value); }
 
     /*! \brief Return the number of frames that will be read from the file per second.
      *

--- a/Holovibes/includes/api/input_api.hh
+++ b/Holovibes/includes/api/input_api.hh
@@ -110,6 +110,20 @@ class InputApi : public IApi
      */
     inline void set_load_file_in_gpu(bool value) const { UPDATE_SETTING(LoadFileInGPU, value); }
 
+    /*! \brief Return whether the full file will be loaded in the CPU memory (RAM) or not. It's used similarly to
+     * LoadFileInGPU but this allows for more GPU memory space available, as RAM is less used than GPU memory.
+     *
+     * \return bool true if the full file will be loaded in the RAM
+     */
+    inline bool get_load_file_in_RAM() const { return GET_SETTING(LoadFileInRAM); }
+
+    /*! \brief Set whether the full file will be loaded in the CPU memory (RAM) or not. It's used similarly to
+     * LoadFileInGPU but this allows for more GPU memory space available, as RAM is less used than GPU memory.
+     *
+     * \param[in] value true if the full file will be loaded in the RAM
+     */
+    inline void set_load_file_in_ram(bool value) const { UPDATE_SETTING(LoadFileInRAM, value); }
+
     /*! \brief Return the number of frames that will be read from the file per second.
      *
      * \return uint the input fps

--- a/Holovibes/includes/core/holovibes.hh
+++ b/Holovibes/includes/core/holovibes.hh
@@ -42,14 +42,13 @@
     holovibes::settings::ImportType,                             \
     holovibes::settings::CameraKind,                             \
     holovibes::settings::FileBufferSize,                         \
-    holovibes::settings::LoadFileInGPU,                          \
-    holovibes::settings::LoadFileInRAM,                          \
+    holovibes::settings::FileLoadKind,                           \
     holovibes::settings::InputFileStartIndex,                    \
     holovibes::settings::InputFileEndIndex,                      \
     holovibes::settings::RecordFilePath,                         \
     holovibes::settings::RecordFrameCount,                       \
     holovibes::settings::RecordMode,                             \
-    holovibes::settings::RecordFrameOffset,                        \
+    holovibes::settings::RecordFrameOffset,                      \
     holovibes::settings::OutputBufferSize,                       \
     holovibes::settings::ImageType,                              \
     holovibes::settings::X,                                      \
@@ -373,8 +372,7 @@ class Holovibes
                                              settings::ImportedFileFd{camera::FrameDescriptor{}},
                                              settings::CameraKind{CameraKind::NONE},
                                              settings::FileBufferSize{1024},
-                                             settings::LoadFileInGPU{false},
-                                             settings::LoadFileInRAM{false},
+                                             settings::FileLoadKind{FileLoadKind::REGULAR},
                                              settings::InputFileStartIndex{0},
                                              settings::InputFileEndIndex{60},
                                              settings::RecordFilePath{std::string("")},

--- a/Holovibes/includes/core/holovibes.hh
+++ b/Holovibes/includes/core/holovibes.hh
@@ -43,6 +43,7 @@
     holovibes::settings::CameraKind,                             \
     holovibes::settings::FileBufferSize,                         \
     holovibes::settings::LoadFileInGPU,                          \
+    holovibes::settings::LoadFileInRAM,                          \
     holovibes::settings::InputFileStartIndex,                    \
     holovibes::settings::InputFileEndIndex,                      \
     holovibes::settings::RecordFilePath,                         \
@@ -373,6 +374,7 @@ class Holovibes
                                              settings::CameraKind{CameraKind::NONE},
                                              settings::FileBufferSize{1024},
                                              settings::LoadFileInGPU{false},
+                                             settings::LoadFileInRAM{false},
                                              settings::InputFileStartIndex{0},
                                              settings::InputFileEndIndex{60},
                                              settings::RecordFilePath{std::string("")},

--- a/Holovibes/includes/enum/enum_file_load_kind.hh
+++ b/Holovibes/includes/enum/enum_file_load_kind.hh
@@ -1,0 +1,22 @@
+/*! \file
+ *
+ * \brief Enum for the different ways to read from a file
+ */
+#pragma once
+
+#include "all_struct.hh"
+
+namespace holovibes
+{
+/*! \enum Device
+ *
+ * \brief Input processes
+ */
+enum class FileLoadKind
+{
+    REGULAR = 0, /*!< Frames are read 'batch' by batch as the computation goes along */
+    GPU,         /*!< The whole file is loaded at once in the GPU VRAM */
+    CPU,         /*!< The whole file is loaded at once in the CPU RAM */
+};
+
+} // namespace holovibes

--- a/Holovibes/includes/gui/windows/panels/import_panel.hh
+++ b/Holovibes/includes/gui/windows/panels/import_panel.hh
@@ -62,8 +62,17 @@ class ImportPanel : public Panel
 
     /**
      * @brief Handles the update of the load file in GPU in the UI.
+     *
+     * \param enabled Whether or not to enable loading the file in GPU
      */
-    void update_load_file_in_gpu();
+    void update_load_file_in_gpu(bool enabled);
+
+    /**
+     * @brief Handles the update of the load file in RAM in the UI.
+     *
+     * \param enabled Whether or not to enable loading the file in RAM
+     */
+    void update_load_file_in_ram(bool enabled);
 
     /**
      * @brief Handles the update of the input file start index in the UI.

--- a/Holovibes/includes/gui/windows/panels/import_panel.hh
+++ b/Holovibes/includes/gui/windows/panels/import_panel.hh
@@ -55,32 +55,32 @@ class ImportPanel : public Panel
      */
     void update_fps();
 
-    /**
-     * @brief Handles the update of the import file path in the UI.
+    /*!
+     * \brief Handles the update of the import file path in the UI.
      */
     void update_import_file_path();
 
-    /**
-     * @brief Handles the update of the load file in GPU in the UI.
+    /*!
+     * \brief Handles the update of the load file in GPU in the UI.
      *
-     * \param enabled Whether or not to enable loading the file in GPU
+     * \param enabled[in] Whether or not to enable loading the file in GPU
      */
     void update_load_file_in_gpu(bool enabled);
 
-    /**
-     * @brief Handles the update of the load file in RAM in the UI.
+    /*!
+     * \brief Handles the update of the load file in RAM in the UI.
      *
-     * \param enabled Whether or not to enable loading the file in RAM
+     * \param enabled[in] Whether or not to enable loading the file in RAM
      */
     void update_load_file_in_ram(bool enabled);
 
-    /**
-     * @brief Handles the update of the input file start index in the UI.
+    /*!
+     * \brief Handles the update of the input file start index in the UI.
      */
     void update_input_file_start_index();
 
-    /**
-     * @brief Handles the update of the input file end index in the UI.
+    /*!
+     * \brief Handles the update of the input file end index in the UI.
      */
     void update_input_file_end_index();
 };

--- a/Holovibes/includes/gui/windows/panels/import_panel.hh
+++ b/Holovibes/includes/gui/windows/panels/import_panel.hh
@@ -61,18 +61,11 @@ class ImportPanel : public Panel
     void update_import_file_path();
 
     /*!
-     * \brief Handles the update of the load file in GPU in the UI.
+     * \brief Handles the update of the load file kind in the UI.
      *
-     * \param enabled[in] Whether or not to enable loading the file in GPU
+     * \param kind[in] The index of the new way to read from files
      */
-    void update_load_file_in_gpu(bool enabled);
-
-    /*!
-     * \brief Handles the update of the load file in RAM in the UI.
-     *
-     * \param enabled[in] Whether or not to enable loading the file in RAM
-     */
-    void update_load_file_in_ram(bool enabled);
+    void update_file_load_kind(int kind);
 
     /*!
      * \brief Handles the update of the input file start index in the UI.

--- a/Holovibes/includes/settings/settings.hh
+++ b/Holovibes/includes/settings/settings.hh
@@ -52,6 +52,11 @@ DECLARE_SETTING(CameraKind, holovibes::CameraKind);
  * before sending it to the compute pipeline input queue.
  */
 DECLARE_SETTING(LoadFileInGPU, bool);
+/*!
+ * \brief The setting that specifies if we load input file entirely in the CPU RAM
+ * before sending it to the compute pipeline input queue.
+ */
+DECLARE_SETTING(LoadFileInRAM, bool);
 
 /*!
  * \brief The setting that specifies the path of the file where to record

--- a/Holovibes/includes/settings/settings.hh
+++ b/Holovibes/includes/settings/settings.hh
@@ -55,6 +55,7 @@ DECLARE_SETTING(LoadFileInGPU, bool);
 /*!
  * \brief The setting that specifies if we load input file entirely in the CPU RAM
  * before sending it to the compute pipeline input queue.
+ * This is slightly slower than loading in GPU, but it takes no GPU memory
  */
 DECLARE_SETTING(LoadFileInRAM, bool);
 

--- a/Holovibes/includes/settings/settings.hh
+++ b/Holovibes/includes/settings/settings.hh
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <optional>
+#include "enum_file_load_kind.hh"
 #include "enum/enum_record_mode.hh"
 #include "enum/enum_import_type.hh"
 #include "struct/view_struct.hh"
@@ -48,16 +49,9 @@ DECLARE_SETTING(ImportType, holovibes::ImportType);
 DECLARE_SETTING(CameraKind, holovibes::CameraKind);
 
 /*!
- * \brief The setting that specifies if we load input file entirely in GPU
- * before sending it to the compute pipeline input queue.
+ * \brief The setting that specifies how to read frames from a file.
  */
-DECLARE_SETTING(LoadFileInGPU, bool);
-/*!
- * \brief The setting that specifies if we load input file entirely in the CPU RAM
- * before sending it to the compute pipeline input queue.
- * This is slightly slower than loading in GPU, but it takes no GPU memory
- */
-DECLARE_SETTING(LoadFileInRAM, bool);
+DECLARE_SETTING(FileLoadKind, holovibes::FileLoadKind);
 
 /*!
  * \brief The setting that specifies the path of the file where to record
@@ -120,7 +114,7 @@ DECLARE_SETTING(FilterFileName, std::string);
 /*! \name FileReadCache */
 /*!
  * \brief The size of the buffer in CPU memory used to read a file
- * when `LoadFileInGPU` is set to false.
+ * when `FileLoadKind` is not set to GPU.
  */
 DECLARE_SETTING(FileBufferSize, size_t);
 

--- a/Holovibes/includes/thread/file_frame_read_worker.hh
+++ b/Holovibes/includes/thread/file_frame_read_worker.hh
@@ -14,8 +14,7 @@
 #define ONRESTART_SETTINGS                         \
     holovibes::settings::InputFilePath,            \
     holovibes::settings::FileBufferSize,           \
-    holovibes::settings::LoadFileInGPU,            \
-    holovibes::settings::LoadFileInRAM,            \
+    holovibes::settings::FileLoadKind,             \
     holovibes::settings::InputFileStartIndex,      \
     holovibes::settings::InputFileEndIndex
 

--- a/Holovibes/includes/thread/file_frame_read_worker.hh
+++ b/Holovibes/includes/thread/file_frame_read_worker.hh
@@ -153,7 +153,7 @@ class FileFrameReadWorker final : public FrameReadWorker
      * Read all the frames in cpu and copy them in gpu.
      * Then enqueue the frames one by one in the input_queue
      */
-    void read_file_in_gpu();
+    void read_file_in_memory();
 
     void read_file_in_ram();
 

--- a/Holovibes/includes/thread/file_frame_read_worker.hh
+++ b/Holovibes/includes/thread/file_frame_read_worker.hh
@@ -148,14 +148,12 @@ class FileFrameReadWorker final : public FrameReadWorker
      */
     void remove_fast_update_map_entries();
 
-    /*! \brief Load all the frames of the file in the gpu
+    /*! \brief Load all the frames of the file in the memory, either GPU or RAM
      *
-     * Read all the frames in cpu and copy them in gpu.
+     * Read all the frames in cpu, and copy them in the GPU if the option to is enabled.
      * Then enqueue the frames one by one in the input_queue
      */
     void read_file_in_memory();
-
-    void read_file_in_ram();
 
     /*! \brief Load the frames of the file by batch into the gpu
      *

--- a/Holovibes/includes/thread/file_frame_read_worker.hh
+++ b/Holovibes/includes/thread/file_frame_read_worker.hh
@@ -15,6 +15,7 @@
     holovibes::settings::InputFilePath,            \
     holovibes::settings::FileBufferSize,           \
     holovibes::settings::LoadFileInGPU,            \
+    holovibes::settings::LoadFileInRAM,            \
     holovibes::settings::InputFileStartIndex,      \
     holovibes::settings::InputFileEndIndex
 
@@ -153,6 +154,8 @@ class FileFrameReadWorker final : public FrameReadWorker
      * Then enqueue the frames one by one in the input_queue
      */
     void read_file_in_gpu();
+
+    void read_file_in_ram();
 
     /*! \brief Load the frames of the file by batch into the gpu
      *

--- a/Holovibes/sources/api/input_api.cc
+++ b/Holovibes/sources/api/input_api.cc
@@ -67,8 +67,8 @@ bool InputApi::import_start() const
     camera_none();
     api_->compute.set_is_computation_stopped(false);
 
-    // if the file is to be imported in GPU, we should load the buffer preset for such case
-    if (get_load_file_in_gpu())
+    // if the file is to be imported in GPU (or CPU RAM), we should load the buffer preset for such case
+    if (get_file_load_kind() != FileLoadKind::REGULAR)
         NotifierManager::notify<bool>("set_preset_file_gpu", true);
 
     try

--- a/Holovibes/sources/gui/windows/panels/import_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/import_panel.cc
@@ -45,6 +45,7 @@ void ImportPanel::load_gui(const json& j_us)
     update_fps(); // Required as it is called `OnEditedFinished` only.
 
     ui_->LoadFileInGpuCheckBox->setChecked(json_get_or_default(j_us, false, "import", "from gpu"));
+    ui_->LoadFileInRamCheckBox->setChecked(json_get_or_default(j_us, false, "import", "from ram"));
 }
 
 void ImportPanel::save_gui(json& j_us)
@@ -53,6 +54,7 @@ void ImportPanel::save_gui(json& j_us)
 
     j_us["import"]["fps"] = ui_->ImportInputFpsSpinBox->value();
     j_us["import"]["from gpu"] = ui_->LoadFileInGpuCheckBox->isChecked();
+    j_us["import"]["from ram"] = ui_->LoadFileInRamCheckBox->isChecked();
 }
 
 std::string& ImportPanel::get_file_input_directory()

--- a/Holovibes/sources/gui/windows/panels/import_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/import_panel.cc
@@ -33,6 +33,8 @@ void ImportPanel::on_notify()
     const bool no_comp = api_.compute.get_is_computation_stopped();
     ui_->InputBrowseToolButton->setEnabled(no_comp);
     ui_->FileReaderProgressBar->setVisible(!no_comp && api_.input.get_import_type() == ImportType::File);
+
+    ui_->FileLoadKindComboBox->setCurrentIndex(static_cast<int>(api_.input.get_file_load_kind()));
 }
 
 void ImportPanel::load_gui(const json& j_us)
@@ -44,8 +46,7 @@ void ImportPanel::load_gui(const json& j_us)
     ui_->ImportInputFpsSpinBox->setValue(json_get_or_default(j_us, 10000, "import", "fps"));
     update_fps(); // Required as it is called `OnEditedFinished` only.
 
-    ui_->LoadFileInGpuCheckBox->setChecked(json_get_or_default(j_us, false, "import", "from gpu"));
-    ui_->LoadFileInRamCheckBox->setChecked(json_get_or_default(j_us, false, "import", "from ram"));
+    ui_->FileLoadKindComboBox->setCurrentIndex(json_get_or_default(j_us, 0, "import", "load file kind"));
 }
 
 void ImportPanel::save_gui(json& j_us)
@@ -53,8 +54,7 @@ void ImportPanel::save_gui(json& j_us)
     j_us["panels"]["import export hidden"] = ui_->ImportExportFrame->isHidden();
 
     j_us["import"]["fps"] = ui_->ImportInputFpsSpinBox->value();
-    j_us["import"]["from gpu"] = ui_->LoadFileInGpuCheckBox->isChecked();
-    j_us["import"]["from ram"] = ui_->LoadFileInRamCheckBox->isChecked();
+    j_us["import"]["load file kind"] = ui_->FileLoadKindComboBox->currentIndex();
 }
 
 std::string& ImportPanel::get_file_input_directory()
@@ -146,19 +146,7 @@ void ImportPanel::update_import_file_path()
     api_.input.set_input_file_path(ui_->ImportPathLineEdit->text().toStdString());
 }
 
-void ImportPanel::update_load_file_in_gpu(bool enabled)
-{
-    api_.input.set_load_file_in_gpu(enabled);
-    if (enabled)
-        ui_->LoadFileInRamCheckBox->setChecked(false);
-}
-
-void ImportPanel::update_load_file_in_ram(bool enabled)
-{
-    api_.input.set_load_file_in_ram(enabled);
-    if (enabled)
-        ui_->LoadFileInGpuCheckBox->setChecked(false);
-}
+void ImportPanel::update_file_load_kind(int kind) { api_.input.set_file_load_kind(static_cast<FileLoadKind>(kind)); }
 
 void ImportPanel::update_input_file_start_index()
 {

--- a/Holovibes/sources/gui/windows/panels/import_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/import_panel.cc
@@ -144,9 +144,18 @@ void ImportPanel::update_import_file_path()
     api_.input.set_input_file_path(ui_->ImportPathLineEdit->text().toStdString());
 }
 
-void ImportPanel::update_load_file_in_gpu()
+void ImportPanel::update_load_file_in_gpu(bool enabled)
 {
-    api_.input.set_load_file_in_gpu(ui_->LoadFileInGpuCheckBox->isChecked());
+    api_.input.set_load_file_in_gpu(enabled);
+    if (enabled)
+        ui_->LoadFileInRamCheckBox->setChecked(false);
+}
+
+void ImportPanel::update_load_file_in_ram(bool enabled)
+{
+    api_.input.set_load_file_in_ram(enabled);
+    if (enabled)
+        ui_->LoadFileInGpuCheckBox->setChecked(false);
 }
 
 void ImportPanel::update_input_file_start_index()

--- a/Holovibes/sources/thread/file_frame_read_worker.cc
+++ b/Holovibes/sources/thread/file_frame_read_worker.cc
@@ -273,7 +273,7 @@ void FileFrameReadWorker::enqueue_loop(size_t nb_frames_to_enqueue)
 {
     size_t frames_enqueued = 0;
     // Read in either cpu or gpu depending on the settings
-    char* buffer = setting<settings::LoadFileInRAM>() ? cpu_frame_buffer_ : gpu_file_frame_buffer_;
+    char* frame_buffer = setting<settings::LoadFileInRAM>() ? cpu_frame_buffer_ : gpu_file_frame_buffer_;
     auto enqueue_kind = setting<settings::LoadFileInRAM>() ? cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice;
     while (frames_enqueued < nb_frames_to_enqueue && !stop_requested_)
     {
@@ -289,7 +289,7 @@ void FileFrameReadWorker::enqueue_loop(size_t nb_frames_to_enqueue)
             {
             }
         }
-        input_queue_.load()->enqueue(buffer + frames_enqueued * frame_size_, enqueue_kind, real_frames_enqueued);
+        input_queue_.load()->enqueue(frame_buffer + frames_enqueued * frame_size_, enqueue_kind, real_frames_enqueued);
 
         current_nb_frames_read_ += real_frames_enqueued;
         frames_enqueued += real_frames_enqueued;


### PR DESCRIPTION
Similarly to LoadFileInGPU, a file can now be loaded in the RAM.
This new option and the checkbox 'Load file in GPU' have been integrated into a new drop-down menu that allows the user to choose how to load a file.

It seems that doing this increases the process time, but slightly slower than in GPU mode. However, no GPU memory is used.

This was an @Hpn4 suggestion, approved by Michael.