### PR TITLE
Fix p index 1-based handling not allowing last frequency

### DIFF
--- a/Holovibes/assets/ui/mainwindow.ui
+++ b/Holovibes/assets/ui/mainwindow.ui
@@ -1051,7 +1051,7 @@ The range of frequencies kept is [z, z + width].</string>
               <string>index of the image displayed</string>
              </property>
              <property name="minimum">
-              <number>0</number>
+              <number>1</number>
              </property>
             </widget>
            </item>

--- a/Holovibes/sources/api/transform_api.cc
+++ b/Holovibes/sources/api/transform_api.cc
@@ -150,7 +150,7 @@ void TransformApi::set_p_index(uint value) const
 
     if (value >= get_time_transformation_size() || value == 0)
     {
-        LOG_ERROR("p param has to be between 1 and #img");
+        LOG_WARN("p param has to be between 1 and #img");
         return;
     }
 

--- a/Holovibes/sources/gui/windows/panels/view_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/view_panel.cc
@@ -176,8 +176,9 @@ void ViewPanel::on_notify()
     api_.transform.check_p_limits(); // FIXME: May be moved in setters
 
     // Enforce maximum value for p_index and p_accu_level
-    ui_->PSpinBox->setMaximum(api_.transform.get_time_transformation_size() - api_.transform.get_p_accu_level() - 1);
-    ui_->PAccSpinBox->setMaximum(api_.transform.get_time_transformation_size() - api_.transform.get_p_index() - 1);
+    // P is 1-based
+    ui_->PSpinBox->setMaximum(api_.transform.get_time_transformation_size() - api_.transform.get_p_accu_level());
+    ui_->PAccSpinBox->setMaximum(api_.transform.get_time_transformation_size() - api_.transform.get_p_index());
     ui_->PSpinBox->setEnabled(!is_raw && api_.compute.get_img_type() != ImgType::Composite);
     ui_->PSpinBox->setVisible(is_data_not_moments);
     ui_->PLabel->setVisible(is_data_not_moments);


### PR DESCRIPTION
Change PSpinBox and PAccSpinBox to be 1-based, allowing to include the last frequency of the range
Also changes the p param out of range log from error to warning as wanted Michael
Need to verify we're not still skipping a frequency index (such as the 0 one)

EDIT: fftfreq in dev is wrong if we compare to matlab but matlab version skips the 0 frequency which is weird
need to ask michael to agree on the way to represent fftfreq (should we include 0 and both positive and negative frequencies ? What about CUDA FFT handling of this ? Does it just keep one of the two ±N/2 or both?)