### PR TITLE
Fix fftfreq Nyquist frequency handling for moments

### DIFF
--- a/Holovibes/cuda_includes/tools_compute.cuh
+++ b/Holovibes/cuda_includes/tools_compute.cuh
@@ -64,3 +64,21 @@ void tensor_multiply_vector(float* output,
                             const ushort f_start,
                             const ushort f_end,
                             const cudaStream_t stream);
+
+void remove_nyquist_freq(float* input_output,
+                         const float* tensor,
+                         const float* vector,
+                         const size_t frame_res,
+                         const ushort f_start,
+                         const ushort f_end,
+                         const ushort nyquist_index,
+                         const cudaStream_t stream);
+
+void add_nyquist_freq(float* input_output,
+                      const float* tensor,
+                      const float* vector,
+                      const size_t frame_res,
+                      const ushort f_start,
+                      const ushort f_end,
+                      const ushort nyquist_index,
+                      const cudaStream_t stream);

--- a/Holovibes/cuda_includes/tools_compute.cuh
+++ b/Holovibes/cuda_includes/tools_compute.cuh
@@ -63,6 +63,9 @@ void tensor_multiply_vector(float* output,
                             const size_t frame_res,
                             const ushort f_start,
                             const ushort f_end,
+                            const size_t nyquist_freq,
+                            bool even,
+                            bool m1,
                             const cudaStream_t stream);
 
 void remove_nyquist_freq(float* input_output,

--- a/Holovibes/cuda_includes/tools_compute.cuh
+++ b/Holovibes/cuda_includes/tools_compute.cuh
@@ -69,16 +69,12 @@ void remove_nyquist_freq(float* input_output,
                          const float* tensor,
                          const float* vector,
                          const size_t frame_res,
-                         const ushort f_start,
-                         const ushort f_end,
-                         const ushort nyquist_index,
+                         const size_t nyquist_index,
                          const cudaStream_t stream);
 
 void add_nyquist_freq(float* input_output,
                       const float* tensor,
                       const float* vector,
                       const size_t frame_res,
-                      const ushort f_start,
-                      const ushort f_end,
-                      const ushort nyquist_index,
+                      const size_t nyquist_index,
                       const cudaStream_t stream);

--- a/Holovibes/cuda_includes/tools_compute.cuh
+++ b/Holovibes/cuda_includes/tools_compute.cuh
@@ -55,6 +55,9 @@ void gpu_normalize(float* const input,
  * \param[in]  frame_res  The resolution of a single frame
  * \param[in]  f_start    The start index
  * \param[in]  f_end      The end indexes
+ * \param[in]  f_end      The index of the nyquist frequency
+ * \param[in]  even       Boolean true if time transform size is even
+ * \param[in]  m1         Boolean true if we are calculating M1
  * \param[in]  stream     The cuda stream
  */
 void tensor_multiply_vector(float* output,
@@ -67,17 +70,3 @@ void tensor_multiply_vector(float* output,
                             bool even,
                             bool m1,
                             const cudaStream_t stream);
-
-void remove_nyquist_freq(float* input_output,
-                         const float* tensor,
-                         const float* vector,
-                         const size_t frame_res,
-                         const size_t nyquist_index,
-                         const cudaStream_t stream);
-
-void add_nyquist_freq(float* input_output,
-                      const float* tensor,
-                      const float* vector,
-                      const size_t frame_res,
-                      const size_t nyquist_index,
-                      const cudaStream_t stream);

--- a/Holovibes/cuda_includes/tools_compute.cuh
+++ b/Holovibes/cuda_includes/tools_compute.cuh
@@ -40,7 +40,8 @@ void gpu_normalize(float* const input,
                    const cudaStream_t stream);
 
 /*!
- * \brief Performs tensor vector multiplication. Parallelisation is done along frame_res.
+ * \brief Performs tensor vector multiplication. Parallelisation is
+ * done along frame_res.
  *
  * - The tensor is a cube of images of size `frame_res` and of depth `TimeTransformationSize`.
  * - The vector is a 1D array of scalar of size `TimeTransformationSize`.
@@ -56,8 +57,6 @@ void gpu_normalize(float* const input,
  * \param[in]  f_start    The start index
  * \param[in]  f_end      The end indexes
  * \param[in]  f_end      The index of the nyquist frequency
- * \param[in]  even       Boolean true if time transform size is even
- * \param[in]  m1         Boolean true if we are calculating M1
  * \param[in]  stream     The cuda stream
  */
 void tensor_multiply_vector(float* output,
@@ -66,7 +65,38 @@ void tensor_multiply_vector(float* output,
                             const size_t frame_res,
                             const ushort f_start,
                             const ushort f_end,
-                            const size_t nyquist_freq,
-                            bool even,
-                            bool m1,
                             const cudaStream_t stream);
+
+/*!
+ * \brief Performs tensor vector multiplication and taking account Nyquist frequency compensation. Parallelisation is
+ * done along frame_res.
+ *
+ * - The tensor is a cube of images of size `frame_res` and of depth `TimeTransformationSize`.
+ * - The vector is a 1D array of scalar of size `TimeTransformationSize`.
+ * - The ouput is a single image of size `frame_res`.
+ *
+ * The function multiply each images in the tensor in the range [f_start, f_end] which the corresponding scalar in the
+ * vector. Then it sums the resulting images in the same range and stores the result in output.
+ *
+ * \param[out] output           The buffer in which to store the result (size: frame_res)
+ * \param[in]  tensor           The tensor
+ * \param[in]  vector           The vector
+ * \param[in]  frame_res        The resolution of a single frame
+ * \param[in]  f_start          The start index
+ * \param[in]  f_end            The end indexes
+ * \param[in]  f_end            The index of the nyquist frequency
+ * \param[in]  nyquist_freq     The index of the Nyquist frequency in vector
+ * \param[in]  even             Boolean true if time transform size is even
+ * \param[in]  m1               Boolean true if we are calculating M1
+ * \param[in]  stream           The cuda stream
+ */
+void tensor_multiply_vector_nyquist_compensation(float* output,
+                                                 const float* tensor,
+                                                 const float* vector,
+                                                 const size_t frame_res,
+                                                 const ushort f_start,
+                                                 const ushort f_end,
+                                                 const size_t nyquist_freq,
+                                                 bool even,
+                                                 bool m1,
+                                                 const cudaStream_t stream);

--- a/Holovibes/cuda_sources/tools_compute.cu
+++ b/Holovibes/cuda_sources/tools_compute.cu
@@ -51,17 +51,19 @@ __global__ void kernel_tensor_multiply_vector_nyquist_compensation(float* output
         return;
 
     float val = 0.0f;
-    for (uint i = f_start; i < nyquist_index; i++)
+    uint i = f_start;
+    for (; i < nyquist_index; i++)
     {
         const float* current_frame = tensor + i * frame_res;
         val += current_frame[index] * vector[i];
     }
 
     // Nyquist frequency handling, when even time window must be doubled for M0/M2, zero for M1
+    // Boolean arithmetic logic is used to avoid conditional in kernel
     const float* current_frame = tensor + nyquist_index * frame_res;
-    val += (1.f + even) * current_frame[index] * vector[nyquist_index] * !(m1 && even);
+    val += (i <= f_end) * (1.f + even) * current_frame[index] * vector[nyquist_index] * !(m1 && even);
 
-    for (uint i = nyquist_index + 1; i < f_end; i++)
+    for (i = nyquist_index + 1; i <= f_end; i++)
     {
         const float* current_frame = tensor + i * frame_res;
         val += current_frame[index] * vector[i];

--- a/Holovibes/cuda_sources/tools_compute.cu
+++ b/Holovibes/cuda_sources/tools_compute.cu
@@ -61,7 +61,7 @@ __global__ void kernel_tensor_multiply_vector_nyquist_compensation(float* output
     // Nyquist frequency handling, when even time window must be doubled for M0/M2, zero for M1
     // Boolean arithmetic logic is used to avoid conditional in kernel
     const float* current_frame = tensor + nyquist_index * frame_res;
-    val += (i <= f_end) * (1.f + even) * current_frame[index] * vector[nyquist_index] * !(m1 && even);
+    val += (i <= f_end) * (1.f + even) * !(m1 && even) * current_frame[index] * vector[nyquist_index];
 
     for (i = nyquist_index + 1; i <= f_end; i++)
     {

--- a/Holovibes/cuda_sources/tools_compute.cu
+++ b/Holovibes/cuda_sources/tools_compute.cu
@@ -70,14 +70,8 @@ void tensor_multiply_vector(float* output,
     kernel_tensor_multiply_vector<<<blocks, threads, 0, stream>>>(output, tensor, vector, frame_res, f_start, f_end);
     cudaCheckError();
 }
-
-static __global__ void kernel_remove_nyquist_freq(float* input_output,
-                                                  const float* tensor,
-                                                  const float* vector,
-                                                  const size_t frame_res,
-                                                  const ushort f_start,
-                                                  const ushort f_end,
-                                                  const ushort nyquist_index)
+static __global__ void kernel_remove_nyquist_freq(
+    float* input_output, const float* tensor, const float* vector, const size_t frame_res, const size_t nyquist_index)
 {
     const uint index = blockIdx.x * blockDim.x + threadIdx.x;
 
@@ -85,37 +79,25 @@ static __global__ void kernel_remove_nyquist_freq(float* input_output,
         return;
 
     const float* current_frame = tensor + nyquist_index * frame_res;
-    input_output[index] -= current_frame[index] * vector[nyquist_index];
+    float val = current_frame[index] * vector[nyquist_index];
+    input_output[index] -= val;
 }
 
 void remove_nyquist_freq(float* input_output,
                          const float* tensor,
                          const float* vector,
                          const size_t frame_res,
-                         const ushort f_start,
-                         const ushort f_end,
-                         const ushort nyquist_index,
+                         const size_t nyquist_index,
                          const cudaStream_t stream)
 {
     uint threads = get_max_threads_1d();
     uint blocks = map_blocks_to_problem(frame_res, threads);
-    kernel_remove_nyquist_freq<<<blocks, threads, 0, stream>>>(input_output,
-                                                               tensor,
-                                                               vector,
-                                                               frame_res,
-                                                               f_start,
-                                                               f_end,
-                                                               nyquist_index);
+    kernel_remove_nyquist_freq<<<blocks, threads, 0, stream>>>(input_output, tensor, vector, frame_res, nyquist_index);
     cudaCheckError();
 }
 
-static __global__ void kernel_add_nyquist_freq(float* input_output,
-                                               const float* tensor,
-                                               const float* vector,
-                                               const size_t frame_res,
-                                               const ushort f_start,
-                                               const ushort f_end,
-                                               const ushort nyquist_index)
+static __global__ void kernel_add_nyquist_freq(
+    float* input_output, const float* tensor, const float* vector, const size_t frame_res, const size_t nyquist_index)
 {
     const uint index = blockIdx.x * blockDim.x + threadIdx.x;
 
@@ -123,27 +105,20 @@ static __global__ void kernel_add_nyquist_freq(float* input_output,
         return;
 
     const float* current_frame = tensor + nyquist_index * frame_res;
-    input_output[index] += current_frame[index] * vector[nyquist_index];
+    float val = current_frame[index] * vector[nyquist_index];
+    input_output[index] += val;
 }
 
 void add_nyquist_freq(float* input_output,
                       const float* tensor,
                       const float* vector,
                       const size_t frame_res,
-                      const ushort f_start,
-                      const ushort f_end,
-                      const ushort nyquist_index,
+                      const size_t nyquist_index,
                       const cudaStream_t stream)
 {
     uint threads = get_max_threads_1d();
     uint blocks = map_blocks_to_problem(frame_res, threads);
-    kernel_add_nyquist_freq<<<blocks, threads, 0, stream>>>(input_output,
-                                                            tensor,
-                                                            vector,
-                                                            frame_res,
-                                                            f_start,
-                                                            f_end,
-                                                            nyquist_index);
+    kernel_add_nyquist_freq<<<blocks, threads, 0, stream>>>(input_output, tensor, vector, frame_res, nyquist_index);
     cudaCheckError();
 }
 

--- a/Holovibes/cuda_sources/tools_compute.cu
+++ b/Holovibes/cuda_sources/tools_compute.cu
@@ -116,57 +116,6 @@ void tensor_multiply_vector(float* output,
                                                                                        m1);
     cudaCheckError();
 }
-static __global__ void kernel_remove_nyquist_freq(
-    float* input_output, const float* tensor, const float* vector, const size_t frame_res, const size_t nyquist_index)
-{
-    const uint index = blockIdx.x * blockDim.x + threadIdx.x;
-
-    if (index >= frame_res)
-        return;
-
-    const float* current_frame = tensor + nyquist_index * frame_res;
-    float val = current_frame[index] * vector[nyquist_index];
-    input_output[index] -= val;
-}
-
-void remove_nyquist_freq(float* input_output,
-                         const float* tensor,
-                         const float* vector,
-                         const size_t frame_res,
-                         const size_t nyquist_index,
-                         const cudaStream_t stream)
-{
-    uint threads = get_max_threads_1d();
-    uint blocks = map_blocks_to_problem(frame_res, threads);
-    kernel_remove_nyquist_freq<<<blocks, threads, 0, stream>>>(input_output, tensor, vector, frame_res, nyquist_index);
-    cudaCheckError();
-}
-
-static __global__ void kernel_add_nyquist_freq(
-    float* input_output, const float* tensor, const float* vector, const size_t frame_res, const size_t nyquist_index)
-{
-    const uint index = blockIdx.x * blockDim.x + threadIdx.x;
-
-    if (index >= frame_res)
-        return;
-
-    const float* current_frame = tensor + nyquist_index * frame_res;
-    float val = current_frame[index] * vector[nyquist_index];
-    input_output[index] += val;
-}
-
-void add_nyquist_freq(float* input_output,
-                      const float* tensor,
-                      const float* vector,
-                      const size_t frame_res,
-                      const size_t nyquist_index,
-                      const cudaStream_t stream)
-{
-    uint threads = get_max_threads_1d();
-    uint blocks = map_blocks_to_problem(frame_res, threads);
-    kernel_add_nyquist_freq<<<blocks, threads, 0, stream>>>(input_output, tensor, vector, frame_res, nyquist_index);
-    cudaCheckError();
-}
 
 void gpu_normalize(float* const input,
                    double* const result_reduce,

--- a/Holovibes/sources/api/transform_api.cc
+++ b/Holovibes/sources/api/transform_api.cc
@@ -148,9 +148,9 @@ void TransformApi::set_p_index(uint value) const
     if (api_->compute.get_compute_mode() == Computation::Raw)
         return;
 
-    if (value >= get_time_transformation_size() || value == 0)
+    if (value >= get_time_transformation_size())
     {
-        LOG_ERROR("p param has to be between 1 and #img");
+        LOG_ERROR("p param has to be between 0 and #img");
         return;
     }
 

--- a/Holovibes/sources/compute/fourier_transform.cc
+++ b/Holovibes/sources/compute/fourier_transform.cc
@@ -238,7 +238,46 @@ void FourierTransform::insert_stft()
                  time_transformation_env_.stft_plan);
         });
 }
+template <typename T>
+void write_1D_array_to_file(const T* array, int rows, int cols, const std::string& filename)
+{
+    // Open the file in write mode
+    std::ofstream outFile(filename);
 
+    // Check if the file was opened successfully
+    if (!outFile)
+    {
+        std::cerr << "Error: Unable to open the file " << filename << std::endl;
+        return;
+    }
+
+    // Write the 1D array in row-major order to the file
+    for (int i = 0; i < rows; ++i)
+    {
+        for (int j = 0; j < cols; ++j)
+        {
+            outFile << array[i * cols + j]; // Calculate index in row-major order
+            if (j < cols - 1)
+                outFile << " "; // Separate values in a row by a space
+        }
+        outFile << std::endl; // New line after each row
+    }
+
+    // Close the file
+    outFile.close();
+    std::cout << "1D array written to the file " << filename << std::endl;
+}
+
+template <typename T>
+void print_in_file_gpu(const T* input, uint rows, uint col, std::string filename, cudaStream_t stream)
+{
+    if (input == nullptr)
+        return;
+    T* result = new T[rows * col];
+    cudaXMemcpyAsync(result, input, rows * col * sizeof(T), cudaMemcpyDeviceToHost, stream);
+    cudaXStreamSynchronize(stream);
+    write_1D_array_to_file<T>(result, rows, col, "test_" + filename + ".txt");
+}
 void FourierTransform::insert_moments()
 {
     LOG_FUNC();
@@ -277,41 +316,44 @@ void FourierTransform::insert_moments()
                                    stream_);
         });
 
-    /*  When time transform size is even we need to do some adjustments:
-        Double the Nyquist frequency for each pixel in M0 and M2
-        Suppress the Nyquist frequency for each pixel in M1 (it should cancel itself with its negative counterpart) */
+    /*  When time transform size is even we need to do some adjustments (not done in the kernels above to avoid
+       checking the size at each call):
+        - Double the Nyquist frequency for each pixel in M0 and M2
+        - Suppress the Nyquist frequency for each pixel in M1 (it should cancel itself with its negative counterpart) */
     auto time_transformation_size = setting<settings::TimeTransformationSize>();
-    auto nyquist_index = time_transformation_size / 2;
+    size_t nyquist_index = time_transformation_size / 2;
     if (time_transformation_size % 2 == 0 && nyquist_index >= moments_env_.f_start &&
         nyquist_index <= moments_env_.f_end)
     {
         fn_compute_vect_->push_back(
             [=]()
             {
-                add_nyquist_freq(moments_env_.moment0_buffer,
-                                 moments_env_.stft_res_buffer,
-                                 moments_env_.f0_buffer,
-                                 fd_.get_frame_res(),
-                                 moments_env_.f_start,
-                                 moments_env_.f_end,
-                                 nyquist_index,
-                                 stream_);
+                print_in_file_gpu(moments_env_.moment0_buffer.get(), 512, 512, "before_m0", stream_);
+                remove_nyquist_freq(moments_env_.moment0_buffer,
+                                    moments_env_.stft_res_buffer,
+                                    moments_env_.f0_buffer,
+                                    fd_.get_frame_res(),
+                                    nyquist_index,
+                                    stream_);
+                print_in_file_gpu(moments_env_.moment0_buffer.get(), 512, 512, "after_m0", stream_);
+
+                print_in_file_gpu(moments_env_.moment1_buffer.get(), 512, 512, "before_m1", stream_);
                 remove_nyquist_freq(moments_env_.moment1_buffer,
                                     moments_env_.stft_res_buffer,
                                     moments_env_.f1_buffer,
                                     fd_.get_frame_res(),
-                                    moments_env_.f_start,
-                                    moments_env_.f_end,
                                     nyquist_index,
                                     stream_);
+                print_in_file_gpu(moments_env_.moment1_buffer.get(), 512, 512, "after_m1", stream_);
+
+                print_in_file_gpu(moments_env_.moment2_buffer.get(), 512, 512, "before_m2", stream_);
                 add_nyquist_freq(moments_env_.moment2_buffer,
                                  moments_env_.stft_res_buffer,
                                  moments_env_.f2_buffer,
                                  fd_.get_frame_res(),
-                                 moments_env_.f_start,
-                                 moments_env_.f_end,
                                  nyquist_index,
                                  stream_);
+                print_in_file_gpu(moments_env_.moment2_buffer.get(), 512, 512, "after_m2", stream_);
             });
     }
 }

--- a/Holovibes/sources/compute/fourier_transform.cc
+++ b/Holovibes/sources/compute/fourier_transform.cc
@@ -250,42 +250,42 @@ void FourierTransform::insert_moments()
         {
             // compute the moment of order 0, corresponding to the sequence of frames multiplied by the
             // frequencies at order 0 (all equal to 1)
-            tensor_multiply_vector(moments_env_.moment0_buffer,
-                                   moments_env_.stft_res_buffer,
-                                   moments_env_.f0_buffer,
-                                   fd_.get_frame_res(),
-                                   moments_env_.f_start,
-                                   moments_env_.f_end,
-                                   nyquist_index,
-                                   time_transformation_size % 2 == 0,
-                                   false,
-                                   stream_);
+            tensor_multiply_vector_nyquist_compensation(moments_env_.moment0_buffer,
+                                                        moments_env_.stft_res_buffer,
+                                                        moments_env_.f0_buffer,
+                                                        fd_.get_frame_res(),
+                                                        moments_env_.f_start,
+                                                        moments_env_.f_end,
+                                                        nyquist_index,
+                                                        time_transformation_size % 2 == 0,
+                                                        false,
+                                                        stream_);
 
             // compute the moment of order 1, corresponding to the sequence of frames multiplied by the
             // frequencies at order 1
-            tensor_multiply_vector(moments_env_.moment1_buffer,
-                                   moments_env_.stft_res_buffer,
-                                   moments_env_.f1_buffer,
-                                   fd_.get_frame_res(),
-                                   moments_env_.f_start,
-                                   moments_env_.f_end,
-                                   nyquist_index,
-                                   time_transformation_size % 2 == 0,
-                                   true,
-                                   stream_);
+            tensor_multiply_vector_nyquist_compensation(moments_env_.moment1_buffer,
+                                                        moments_env_.stft_res_buffer,
+                                                        moments_env_.f1_buffer,
+                                                        fd_.get_frame_res(),
+                                                        moments_env_.f_start,
+                                                        moments_env_.f_end,
+                                                        nyquist_index,
+                                                        time_transformation_size % 2 == 0,
+                                                        true,
+                                                        stream_);
 
             // compute the moment of order 2, corresponding to the sequence of frames multiplied by the
             // frequencies at order 2
-            tensor_multiply_vector(moments_env_.moment2_buffer,
-                                   moments_env_.stft_res_buffer,
-                                   moments_env_.f2_buffer,
-                                   fd_.get_frame_res(),
-                                   moments_env_.f_start,
-                                   moments_env_.f_end,
-                                   nyquist_index,
-                                   time_transformation_size % 2 == 0,
-                                   false,
-                                   stream_);
+            tensor_multiply_vector_nyquist_compensation(moments_env_.moment2_buffer,
+                                                        moments_env_.stft_res_buffer,
+                                                        moments_env_.f2_buffer,
+                                                        fd_.get_frame_res(),
+                                                        moments_env_.f_start,
+                                                        moments_env_.f_end,
+                                                        nyquist_index,
+                                                        time_transformation_size % 2 == 0,
+                                                        false,
+                                                        stream_);
         });
 }
 

--- a/Holovibes/sources/compute/fourier_transform.cc
+++ b/Holovibes/sources/compute/fourier_transform.cc
@@ -238,46 +238,7 @@ void FourierTransform::insert_stft()
                  time_transformation_env_.stft_plan);
         });
 }
-template <typename T>
-void write_1D_array_to_file(const T* array, int rows, int cols, const std::string& filename)
-{
-    // Open the file in write mode
-    std::ofstream outFile(filename);
 
-    // Check if the file was opened successfully
-    if (!outFile)
-    {
-        std::cerr << "Error: Unable to open the file " << filename << std::endl;
-        return;
-    }
-
-    // Write the 1D array in row-major order to the file
-    for (int i = 0; i < rows; ++i)
-    {
-        for (int j = 0; j < cols; ++j)
-        {
-            outFile << array[i * cols + j]; // Calculate index in row-major order
-            if (j < cols - 1)
-                outFile << " "; // Separate values in a row by a space
-        }
-        outFile << std::endl; // New line after each row
-    }
-
-    // Close the file
-    outFile.close();
-    std::cout << "1D array written to the file " << filename << std::endl;
-}
-
-template <typename T>
-void print_in_file_gpu(const T* input, uint rows, uint col, std::string filename, cudaStream_t stream)
-{
-    if (input == nullptr)
-        return;
-    T* result = new T[rows * col];
-    cudaXMemcpyAsync(result, input, rows * col * sizeof(T), cudaMemcpyDeviceToHost, stream);
-    cudaXStreamSynchronize(stream);
-    write_1D_array_to_file<T>(result, rows, col, "test_" + filename + ".txt");
-}
 void FourierTransform::insert_moments()
 {
     LOG_FUNC();
@@ -299,7 +260,6 @@ void FourierTransform::insert_moments()
                                    time_transformation_size % 2 == 0,
                                    false,
                                    stream_);
-            print_in_file_gpu(moments_env_.moment0_buffer.get(), 512, 512, "after_m0", stream_);
 
             // compute the moment of order 1, corresponding to the sequence of frames multiplied by the
             // frequencies at order 1
@@ -313,7 +273,6 @@ void FourierTransform::insert_moments()
                                    time_transformation_size % 2 == 0,
                                    true,
                                    stream_);
-            print_in_file_gpu(moments_env_.moment1_buffer.get(), 512, 512, "after_m1", stream_);
 
             // compute the moment of order 2, corresponding to the sequence of frames multiplied by the
             // frequencies at order 2
@@ -327,7 +286,6 @@ void FourierTransform::insert_moments()
                                    time_transformation_size % 2 == 0,
                                    false,
                                    stream_);
-            print_in_file_gpu(moments_env_.moment2_buffer.get(), 512, 512, "after_m2", stream_);
         });
 }
 

--- a/Holovibes/sources/core/icompute.cc
+++ b/Holovibes/sources/core/icompute.cc
@@ -41,7 +41,7 @@ void ICompute::fft_freqs()
 
     // initialize f1
     // f1 = [0, 1, ...,   n / 2,     -(n - 1) / 2, ..., -1] * fs / n   if n is even
-    // Note: we keep the Nyquist frequency (n / 2) only for the positive, this means f1 is of length n
+    // Note: we keep the Nyquist frequency (n / 2) only for the positive, this means f1 is of length n instead of n + 1
     if (time_transformation_size % 2 == 0)
     {
         for (uint i = 0; i <= time_transformation_size / 2; i++)

--- a/Holovibes/sources/core/icompute.cc
+++ b/Holovibes/sources/core/icompute.cc
@@ -26,7 +26,7 @@ using camera::FrameDescriptor;
 void ICompute::fft_freqs()
 {
     uint time_transformation_size = setting<settings::TimeTransformationSize>();
-    float d = setting<settings::CameraFps>() / static_cast<float>(time_transformation_size);
+    float d = static_cast<float>(setting<settings::CameraFps>()) / static_cast<float>(time_transformation_size);
 
     // We fill our buffers using CPU buffers, since CUDA buffers are not accessible
     std::unique_ptr<float[]> f0(new float[time_transformation_size]);
@@ -40,13 +40,14 @@ void ICompute::fft_freqs()
     cudaXMemcpy(moments_env_.f0_buffer, f0.get(), time_transformation_size * sizeof(float), cudaMemcpyHostToDevice);
 
     // initialize f1
-    // f1 = [0, 1, ...,   n/2-1,     -n/2, ..., -1] * fs / n   if n is even
+    // f1 = [0, 1, ...,   n / 2,     -(n - 1) / 2, ..., -1] * fs / n   if n is even
+    // Note: we keep the Nyquist frequency (n / 2) only for the positive, this means f1 is of length n
     if (time_transformation_size % 2 == 0)
     {
         for (uint i = 0; i <= time_transformation_size / 2; i++)
             f1[i] = i * d;
 
-        for (uint i = time_transformation_size / 2; i < time_transformation_size - 1; i++)
+        for (uint i = time_transformation_size / 2 + 1; i < time_transformation_size; i++)
             f1[i] = -((float)time_transformation_size - i) * d;
     }
     // f1 = [0, 1, ..., (n - 1) / 2, -(n - 1) / 2, ..., -1] * fs / n if n is odd

--- a/Holovibes/sources/core/icompute.cc
+++ b/Holovibes/sources/core/icompute.cc
@@ -26,7 +26,7 @@ using camera::FrameDescriptor;
 void ICompute::fft_freqs()
 {
     uint time_transformation_size = setting<settings::TimeTransformationSize>();
-    float d = static_cast<float>(setting<settings::CameraFps>()) / static_cast<float>(time_transformation_size);
+    float d = static_cast<float>(setting<settings::CameraFps>()) / time_transformation_size;
 
     // We fill our buffers using CPU buffers, since CUDA buffers are not accessible
     std::unique_ptr<float[]> f0(new float[time_transformation_size]);


### PR DESCRIPTION
Fix fft_freq to have the following format when n is even as suggested by Michael
f1 = [0, 1, ...,   n / 2,     -(n - 1) / 2, ..., -1] * fs / n

The Nyquist frequency (n / 2) is only stored once in the positive half of the array, but it also has a negative counterpart
This means that the Nyquist frequency should be counted twice, once for its positive and once for its negative counterpart.
For moments the following should be done:
* for moment 0 and moment 2, this implies doubling the computation at Nyquist index, 
* for moment 1 we need to remove it (it should indeed cancel itself because of its negative counterpart)

TODO:
Check if we should also do the above compensation in other parts of the code