### PR TITLE
In the footer, input_fps is now overriden by camera_fps

### DIFF
--- a/Holovibes/includes/api/input_api.hh
+++ b/Holovibes/includes/api/input_api.hh
@@ -210,6 +210,14 @@ class InputApi : public IApi
      */
     inline void set_camera_fps(uint value) const { UPDATE_SETTING(CameraFps, value); }
 
+    /**
+     * \brief Getter for if a camera is loaded and it can transmit camera fps.
+     *
+     * \return true Camera fps are available
+     * \return false No camera fps are available (either the camera is incompatible or no camera is loaded)
+     */
+    bool can_get_camera_fps() const;
+
     /*! \brief Return the physical pixel size of the camera sensor (the one in use or the one used when recording the
      * file) in µm.
      *

--- a/Holovibes/sources/api/input_api.cc
+++ b/Holovibes/sources/api/input_api.cc
@@ -157,6 +157,17 @@ std::optional<io_files::InputFrameFile*> InputApi::import_file(const std::string
 
 #pragma region Cameras
 
+bool InputApi::can_get_camera_fps() const
+{
+    static const std::vector<CameraKind> compatible_cameras = {CameraKind::Phantom,
+                                                               CameraKind::AutoDetectionPhantom,
+                                                               CameraKind::AmetekS711EuresysCoaxlinkQSFP,
+                                                               CameraKind::AmetekS991EuresysCoaxlinkQSFP,
+                                                               CameraKind::Ametek};
+    return (std::find(compatible_cameras.begin(), compatible_cameras.end(), api_->input.get_camera_kind()) !=
+            compatible_cameras.end());
+}
+
 bool InputApi::set_camera_kind(CameraKind c, bool save) const
 {
     camera_none();

--- a/Holovibes/sources/io/output_file/output_holo_file.cc
+++ b/Holovibes/sources/io/output_file/output_holo_file.cc
@@ -44,9 +44,10 @@ void OutputHoloFile::export_compute_settings(int input_fps, size_t contiguous)
     try
     {
         auto& api = API;
+        int camera_fps = api.input.get_camera_fps() == 0 ? input_fps : api.input.get_camera_fps();
         auto j_fi = json{{"pixel_pitch", {{"x", api.input.get_pixel_size()}, {"y", api.input.get_pixel_size()}}},
-                         {"input_fps", input_fps},
-                         {"camera_fps", api.input.get_camera_fps() == 0 ? input_fps : api.input.get_camera_fps()},
+                         {"input_fps", camera_fps},
+                         {"camera_fps", camera_fps},
                          {"eye_type", api.record.get_recorded_eye()},
                          {"contiguous", contiguous},
                          {"holovibes_version", __HOLOVIBES_VERSION__}};

--- a/Holovibes/sources/io/output_file/output_holo_file.cc
+++ b/Holovibes/sources/io/output_file/output_holo_file.cc
@@ -46,7 +46,7 @@ void OutputHoloFile::export_compute_settings(int input_fps, size_t contiguous)
         auto& api = API;
         int camera_fps = api.input.get_camera_fps() == 0 ? input_fps : api.input.get_camera_fps();
         auto j_fi = json{{"pixel_pitch", {{"x", api.input.get_pixel_size()}, {"y", api.input.get_pixel_size()}}},
-                         {"input_fps", camera_fps},
+                         {"input_fps", API.input.can_get_camera_fps() ? camera_fps : input_fps},
                          {"camera_fps", camera_fps},
                          {"eye_type", api.record.get_recorded_eye()},
                          {"contiguous", contiguous},


### PR DESCRIPTION
This basically means both are the same value at all times (even when the camera isn't an Ametek Phantom).
Michael wants to keep `input_fps` as a transition, so that nothing breaks because it's suddenly gone.