### PR TITLE
Fix recording frame skip + transform api

### DIFF
--- a/Holovibes/assets/style/style.css
+++ b/Holovibes/assets/style/style.css
@@ -13,7 +13,7 @@ QMainWindow {
     background-color: #101111;
 }
 
-/* Text color for disabled and enabld elements */
+/* Text color for disabled and enabled elements */
 QLabel:disabled,
 QMenu::item:disabled,
 QPushButton:disabled,

--- a/Holovibes/assets/style/style.css
+++ b/Holovibes/assets/style/style.css
@@ -15,6 +15,7 @@ QMainWindow {
 
 /* Text color for disabled and enabld elements */
 QLabel:disabled,
+QMenu::item:disabled,
 QPushButton:disabled,
 QToolButton:disabled,
 QTextEdit:disabled,

--- a/Holovibes/includes/api/transform_api.hh
+++ b/Holovibes/includes/api/transform_api.hh
@@ -244,40 +244,24 @@ class TransformApi : public IApi
 
 #pragma region Time Tr.Cuts
 
-    /*! \brief Returns the start index for the x cut accumulation. Is in range [0, `time_transformation_size -
-     * get_x_accu_level - 1`].
+    /*! \brief Checks the limits of the x index and x accu level.
+     *
+     * The x index must be in range [0, `fd.width - get_x_accu_level - 1`].
+     * The x accu level must be in range [0, `fd.width - get_x_cuts - 1`].
+     */
+    void check_x_limits() const;
+
+    /*! \brief Returns the start index for the x cut accumulation. Is in range [0, `fd.width - get_x_accu_level - 1`].
      *
      * \return uint the x cut start index
      */
     inline uint get_x_cuts() const { return GET_SETTING(X).start; }
 
-    /*! \brief Sets the start index for the x cut accumulation. Must be in range [0, `time_transformation_size -
-     * get_x_accu_level - 1`].
+    /*! \brief Sets the start index for the x cut accumulation. Must be in range [0, `fd.width - get_x_accu_level - 1`].
      *
      * \param[in] x_value the new x cut start index
      */
     void set_x_cuts(uint x_value) const;
-
-    /*! \brief Returns the start index for the y cut accumulation. Is in range [0, `time_transformation_size -
-     * get_y_accu_level - 1`].
-     *
-     * \return uint the y cut start index
-     */
-    inline uint get_y_cuts() const { return GET_SETTING(Y).start; }
-
-    /*! \brief Sets the start index for the y cut accumulation. Must be in range [0, `time_transformation_size -
-     * get_y_accu_level - 1`].
-     *
-     * \param[in] y_value the new y cut start index
-     */
-    void set_y_cuts(uint y_value) const;
-
-    /*! \brief Modifies the start index for the x and y cuts accumulation.
-     *
-     * \param[in] x value to modify
-     * \param[in] y value to modify
-     */
-    void set_x_y(uint x, uint y) const;
 
     /*! \brief Returns the x cut accumulation level. Is in range [0, `time_transformation_size - get_x_cuts - 1`].
      *
@@ -290,6 +274,26 @@ class TransformApi : public IApi
      * \param[in] x_value the new x cut accumulation level
      */
     void set_x_accu_level(uint x_value) const;
+
+    /*! \brief Checks the limits of the y index and y accu level.
+     *
+     * The y index must be in range [0, `fd.height - get_y_accu_level - 1`].
+     * The y accu level must be in range [0, `fd.height - get_y_cuts - 1`].
+     */
+    void check_y_limits() const;
+
+    /*! \brief Returns the start index for the y cut accumulation. Is in range [0, `fd.height - get_y_accu_level - 1`].
+     *
+     * \return uint the y cut start index
+     */
+    inline uint get_y_cuts() const { return GET_SETTING(Y).start; }
+
+    /*! \brief Sets the start index for the y cut accumulation. Must be in range [0, `fd.height - get_y_accu_level -
+     * 1`].
+     *
+     * \param[in] y_value the new y cut start index
+     */
+    void set_y_cuts(uint y_value) const;
 
     /*! \brief Returns the y cut accumulation level. Is in range [0, `time_transformation_size - get_y_cuts - 1`].
      *

--- a/Holovibes/includes/api/transform_api.hh
+++ b/Holovibes/includes/api/transform_api.hh
@@ -119,8 +119,9 @@ class TransformApi : public IApi
      * \brief Sets the distance in meter for the z-coordinate (the focus).
      *
      * \param[in] value The new z-coordinate distance in meter.
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    void set_z_distance(float value) const;
+    ApiCode set_z_distance(float value) const;
 
 #pragma endregion
 
@@ -136,18 +137,10 @@ class TransformApi : public IApi
     /*! \brief Modifies the time transformation size. It's the number of frames used for one time transformation. Must
      * be greater than 0.
      *
-     * \param[in] value the new value
-     * \warning This function is not intended for realtime use.
+     * \param[in] time_transformation_size the new value
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    inline void set_time_transformation_size(uint value) const { UPDATE_SETTING(TimeTransformationSize, value); }
-
-    /*! \brief Modifies the time transformation size. It's the number of frames used for one time transformation. Must
-     * be greater than 0.
-     *
-     * \param[in] value the new value
-     * \warning This function is intended for realtime use.
-     */
-    void update_time_transformation_size(uint time_transformation_size) const;
+    ApiCode set_time_transformation_size(uint time_transformation_size) const;
 
     /*! \brief Returns the time transformation algorithm used (STFT, PAC, etc.).
      *
@@ -158,9 +151,9 @@ class TransformApi : public IApi
     /*! \brief Sets the time transformation algorithm used (STFT, PAC, etc.).
      *
      * \param[in] value the new value
-     * \warning This function is intended for realtime use.
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    void set_time_transformation(const TimeTransformation value) const;
+    ApiCode set_time_transformation(const TimeTransformation value) const;
 
 #pragma endregion
 

--- a/Holovibes/includes/api/transform_api.hh
+++ b/Holovibes/includes/api/transform_api.hh
@@ -42,19 +42,11 @@ class TransformApi : public IApi
      *
      * The batch size must be greater than `time_stride`.
      *
-     * \param[in] value the new value
-     * \warning This function is not intended for realtime use.
-     *
-     * \return bool true if the time stride needs to be updated
-     */
-    bool set_batch_size(uint value) const;
-
-    /*! \brief Modifies the batch size. Updates time stride if needed.
-     *
      * \param[in] batch_size the new value
-     * \warning This function is intended for realtime use.
+     *
+     * \return ApiCode the status of the modification: OK or NO_CHANGE.
      */
-    void update_batch_size(uint batch_size) const;
+    ApiCode set_batch_size(uint batch_size) const;
 
 #pragma endregion
 
@@ -81,17 +73,10 @@ class TransformApi : public IApi
      * - `batch_size` = 10, `time_stride` = 60, 6 batch are skipped
      * - `batch_size` = 10, `time_stride` = 10, 0 batch are skipped
      *
-     * \param[in] value the new value
-     * \warning This function is not intended for realtime use.
-     */
-    void set_time_stride(uint value) const;
-
-    /*! \brief Modifies the time stride. Must be a multiple of `batch_size` and greater equal than `batch_size`.
-     *
      * \param[in] time_stride the new value
-     * \warning This function is intended for realtime use.
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    void update_time_stride(const uint time_stride) const;
+    ApiCode set_time_stride(uint time_stride) const;
 
 #pragma endregion
 
@@ -106,9 +91,9 @@ class TransformApi : public IApi
     /*! \brief Modifies the space transformation algorithm used (either Fresnel or Angular Spectrum).
      *
      * \param[in] value the new value
-     * \warning This function is intended for realtime use.
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    void set_space_transformation(const SpaceTransformation value) const;
+    ApiCode set_space_transformation(const SpaceTransformation value) const;
 
     /*! \brief Returns the wave length of the laser (in nm).
      *
@@ -117,11 +102,12 @@ class TransformApi : public IApi
     inline float get_lambda() const { return GET_SETTING(Lambda); }
 
     /*!
-     * \brief Sets the wave length of the laser (in nm).
+     * \brief Sets the wave length of the laser (in nm). Must be positive.
      *
      * \param[in] value the new value (in nm)
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    void set_lambda(float value) const;
+    ApiCode set_lambda(float value) const;
 
     /*! \brief Returns the distance in meter for the z-coordinate (the focus).
      *

--- a/Holovibes/includes/api/transform_api.hh
+++ b/Holovibes/includes/api/transform_api.hh
@@ -259,9 +259,10 @@ class TransformApi : public IApi
 
     /*! \brief Sets the start index for the x cut accumulation. Must be in range [0, `fd.width - get_x_accu_level - 1`].
      *
-     * \param[in] x_value the new x cut start index
+     * \param[in] x_value the new x cut start index.
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    void set_x_cuts(uint x_value) const;
+    ApiCode set_x_cuts(uint x_value) const;
 
     /*! \brief Returns the x cut accumulation level. Is in range [0, `time_transformation_size - get_x_cuts - 1`].
      *
@@ -272,8 +273,9 @@ class TransformApi : public IApi
     /*! \brief Sets the x cut accumulation level. Must be in range [0, `time_transformation_size - get_x_cuts - 1`].
      *
      * \param[in] x_value the new x cut accumulation level
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    void set_x_accu_level(uint x_value) const;
+    ApiCode set_x_accu_level(uint x_value) const;
 
     /*! \brief Checks the limits of the y index and y accu level.
      *
@@ -292,8 +294,9 @@ class TransformApi : public IApi
      * 1`].
      *
      * \param[in] y_value the new y cut start index
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    void set_y_cuts(uint y_value) const;
+    ApiCode set_y_cuts(uint y_value) const;
 
     /*! \brief Returns the y cut accumulation level. Is in range [0, `time_transformation_size - get_y_cuts - 1`].
      *
@@ -304,8 +307,9 @@ class TransformApi : public IApi
     /*! \brief Sets the y cut accumulation level. Must be in range [0, `time_transformation_size - get_y_cuts - 1`].
      *
      * \param[in] y_value the new y cut accumulation level
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    void set_y_accu_level(uint y_value) const;
+    ApiCode set_y_accu_level(uint y_value) const;
 
     /*! \brief Returns the capacity (in number of frames) of the output buffers containing the result of the time
      * transformation cuts.

--- a/Holovibes/includes/api/transform_api.hh
+++ b/Holovibes/includes/api/transform_api.hh
@@ -325,11 +325,9 @@ class TransformApi : public IApi
      * transformation cuts.
      *
      * \param[in] value the new capacity
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    inline void set_time_transformation_cuts_output_buffer_size(uint value) const
-    {
-        UPDATE_SETTING(TimeTransformationCutsOutputBufferSize, value);
-    }
+    ApiCode set_time_transformation_cuts_output_buffer_size(uint value) const;
 
 #pragma endregion
 
@@ -350,14 +348,16 @@ class TransformApi : public IApi
      * reorder them to be from -N/2 to N/2. Where N is the number of frequencies (`time_transformation_size`).
      *
      * \param[in] value true: enable, false: disable
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    void set_fft_shift_enabled(bool value) const;
+    ApiCode set_fft_shift_enabled(const bool value) const;
 
     /*! \brief Enables or Disables unwrapping 2d
      *
      * \param[in] value true: enable, false: disable
+     * \return ApiCode the status of the modification: OK, NO_CHANGE, NOT_STARTED or WRONG_COMP_MODE (if in raw mode).
      */
-    void set_unwrapping_2d(const bool value) const;
+    ApiCode set_unwrapping_2d(const bool value) const;
 
 #pragma endregion
 

--- a/Holovibes/includes/api/transform_api.hh
+++ b/Holovibes/includes/api/transform_api.hh
@@ -176,8 +176,9 @@ class TransformApi : public IApi
      * `get_p_index + get_p_accu_level`] will be accumulated into one image.
      *
      * \param[in] value the new min accumulation frequency
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    void set_p_index(uint value) const;
+    ApiCode set_p_index(uint value) const;
 
     /*! \brief Returns the number of frequencies accumulated for the time transformation. Is in range [0,
      * `time_transformation_size - get_p_index - 1`].
@@ -196,8 +197,9 @@ class TransformApi : public IApi
      * `get_p_index + get_p_accu_level`] will be accumulated into one image.
      *
      * \param[in] p_value the new number of frequencies accumulated
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    void set_p_accu_level(uint p_value) const;
+    ApiCode set_p_accu_level(uint p_value) const;
 
     /*! \brief Returns the min eigen value index kept by the SVD. Is in range [0, `time_transformation_size -
      * get_p_accu_level - 1`].
@@ -214,8 +216,9 @@ class TransformApi : public IApi
      * Only eigen values ranging between [`get_q_index`, `get_q_index + get_q_accu_level`] will be ketp.
      *
      * \param[in] value the new min eigen value index kept
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    void set_q_index(uint value) const;
+    ApiCode set_q_index(uint value) const;
 
     /*! \brief Returns the number of eigen values kept by the SVD. Is in range [0, `time_transformation_size -
      * get_q_index - 1`].
@@ -233,14 +236,9 @@ class TransformApi : public IApi
      * Only eigen values ranging between [`get_q_index`, `get_q_index + get_q_accu_level`] will be ketp.
      *
      * \param[in] value the new number of eigen values kept
+     * \return ApiCode the status of the modification: OK, NO_CHANGE or WRONG_COMP_MODE (if in raw mode).
      */
-    void set_q_accu_level(uint value) const;
-
-    /*! \brief Adjust the value of `p_index` and `p_accu_level` according to `time_transformation_size` */
-    void check_p_limits() const;
-
-    /*! \brief Adjust the value of `q_index` and `q_accu_level` according to `time_transformation_size` */
-    void check_q_limits() const;
+    ApiCode set_q_accu_level(uint value) const;
 
 #pragma endregion
 
@@ -354,6 +352,13 @@ class TransformApi : public IApi
     void set_unwrapping_2d(const bool value) const;
 
 #pragma endregion
+
+  private:
+    /*! \brief Adjust the value of `p_index` and `p_accu_level` according to `time_transformation_size` */
+    void check_p_limits() const;
+
+    /*! \brief Adjust the value of `q_index` and `q_accu_level` according to `time_transformation_size` */
+    void check_q_limits() const;
 };
 
 } // namespace holovibes::api

--- a/Holovibes/includes/core/holovibes.hh
+++ b/Holovibes/includes/core/holovibes.hh
@@ -245,7 +245,12 @@ class Holovibes
      *
      * \return const char* the path of the camera INI file of the current camera.
      */
-    inline const char* get_camera_ini_name() const { return active_camera_->get_ini_name(); }
+    inline const char* get_camera_ini_name() const
+    {
+        if (!active_camera_)
+            return "";
+        return active_camera_->get_ini_name();
+    }
 
     /*! \brief Return whether the recording worker is running or not
      *

--- a/Holovibes/includes/core/icompute.hh
+++ b/Holovibes/includes/core/icompute.hh
@@ -75,6 +75,7 @@
     holovibes::settings::HSV,                                    \
     holovibes::settings::ZFFTShift,                              \
     holovibes::settings::RecordFrameCount,                       \
+    holovibes::settings::FrameSkip,                              \
     holovibes::settings::RecordMode,                             \
     holovibes::settings::CameraFps
 

--- a/Holovibes/sources/api/compute_api.cc
+++ b/Holovibes/sources/api/compute_api.cc
@@ -43,6 +43,10 @@ ApiCode ComputeApi::start() const
     // Stop any computation currently running and file reading
     stop();
 
+    // Check some settings (now that we have the input frame descriptor)
+    api_->transform.check_x_limits();
+    api_->transform.check_y_limits();
+
     // Create the pipe and start the pipe
     Holovibes::instance().start_compute();
     set_is_computation_stopped(false);

--- a/Holovibes/sources/api/globalpostprocess_api.cc
+++ b/Holovibes/sources/api/globalpostprocess_api.cc
@@ -176,7 +176,7 @@ ApiCode GlobalPostProcessApi::enable_convolution(const std::string& filename) co
     {
         auto pipe = api_->compute.get_compute_pipe();
         pipe->request(ICS::Convolution);
-        LOG_ERROR("Convolution requested: {}", get_convo_matrix().size());
+
         // Wait for the convolution to be enabled for notify
         while (pipe->is_requested(ICS::Convolution))
             continue;

--- a/Holovibes/sources/api/record_api.cc
+++ b/Holovibes/sources/api/record_api.cc
@@ -102,9 +102,12 @@ ApiCode RecordApi::start_record(std::function<void()> callback) const
     std::get<1>(*fast_update_progress_entry) = 0; // Frames recorded
     nb_frames_to_record = static_cast<uint>(get_record_frame_count().value_or(0));
 
+    if (nb_frames_to_record.load() > get_nb_frame_skip())
+        nb_frames_to_record -= get_nb_frame_skip();
+
     // Calculate the right number of frames to record
     float pas = get_nb_frame_skip() + 1.0f;
-    nb_frames_to_record = static_cast<uint>(std::ceilf(static_cast<float>(nb_frames_to_record) / pas));
+    nb_frames_to_record = static_cast<uint>(std::floorf(static_cast<float>(nb_frames_to_record) / pas));
     if (record_mode == RecordMode::MOMENTS)
         nb_frames_to_record = nb_frames_to_record * 3;
 

--- a/Holovibes/sources/api/transform_api.cc
+++ b/Holovibes/sources/api/transform_api.cc
@@ -263,6 +263,52 @@ ApiCode TransformApi::set_q_accu_level(uint value) const
 
 #pragma region Time Tr.Cuts
 
+void TransformApi::check_x_limits() const
+{
+    // No input frame descriptor
+    if (api_->input.get_import_type() == ImportType::None)
+        return;
+
+    int upper_bound = static_cast<int>(api_->input.get_input_fd().width) - 1;
+
+    if (std::cmp_greater(get_x_accu_level(), upper_bound))
+    {
+        LOG_WARN("x width is greater than the frame descriptor width, setting it: {}", upper_bound);
+        set_x_accu_level(upper_bound);
+    }
+
+    upper_bound -= get_x_accu_level();
+
+    if (get_x_cuts() > static_cast<uint>(upper_bound))
+    {
+        LOG_WARN("x start + x width is greater than the frame descriptor width, setting x start to: {}", upper_bound);
+        set_x_cuts(upper_bound);
+    }
+}
+
+void TransformApi::check_y_limits() const
+{
+    // No input frame descriptor
+    if (api_->input.get_import_type() == ImportType::None)
+        return;
+
+    int upper_bound = static_cast<int>(api_->input.get_input_fd().height) - 1;
+
+    if (std::cmp_greater(get_y_accu_level(), upper_bound))
+    {
+        LOG_WARN("y width is greater than the frame descriptor height, setting it: {}", upper_bound);
+        set_x_accu_level(upper_bound);
+    }
+
+    upper_bound -= get_y_accu_level();
+
+    if (get_y_cuts() > static_cast<uint>(upper_bound))
+    {
+        LOG_WARN("y start + y width is greater than the frame descriptor height, setting x start to: {}", upper_bound);
+        set_y_cuts(upper_bound);
+    }
+}
+
 void TransformApi::set_x_accu_level(uint x_value) const
 {
     SET_SETTING(X, width, x_value);
@@ -291,20 +337,6 @@ void TransformApi::set_y_cuts(uint value) const
         SET_SETTING(Y, start, value);
         api_->compute.pipe_refresh();
     }
-}
-
-void TransformApi::set_x_y(uint x, uint y) const
-{
-    if (api_->compute.get_compute_mode() == Computation::Raw || api_->compute.get_is_computation_stopped())
-        return;
-
-    if (x < api_->input.get_input_fd().width)
-        SET_SETTING(X, start, x);
-
-    if (y < api_->input.get_input_fd().height)
-        SET_SETTING(Y, start, y);
-
-    api_->compute.pipe_refresh();
 }
 
 #pragma endregion

--- a/Holovibes/sources/api/transform_api.cc
+++ b/Holovibes/sources/api/transform_api.cc
@@ -286,6 +286,30 @@ void TransformApi::check_x_limits() const
     }
 }
 
+ApiCode TransformApi::set_x_accu_level(uint x_value) const
+{
+    NOT_SAME_AND_NOT_RAW(get_x_accu_level(), x_value);
+
+    SET_SETTING(X, width, x_value);
+    check_x_limits();
+
+    api_->compute.pipe_refresh();
+
+    return ApiCode::OK;
+}
+
+ApiCode TransformApi::set_x_cuts(uint value) const
+{
+    NOT_SAME_AND_NOT_RAW(get_x_cuts(), value);
+
+    SET_SETTING(X, start, value);
+    check_x_limits();
+
+    api_->compute.pipe_refresh();
+
+    return ApiCode::OK;
+}
+
 void TransformApi::check_y_limits() const
 {
     // No input frame descriptor
@@ -309,34 +333,28 @@ void TransformApi::check_y_limits() const
     }
 }
 
-void TransformApi::set_x_accu_level(uint x_value) const
+ApiCode TransformApi::set_y_accu_level(uint y_value) const
 {
-    SET_SETTING(X, width, x_value);
-    api_->compute.pipe_refresh();
-}
+    NOT_SAME_AND_NOT_RAW(get_y_accu_level(), y_value);
 
-void TransformApi::set_x_cuts(uint value) const
-{
-    if (value < api_->input.get_input_fd().width)
-    {
-        SET_SETTING(X, start, value);
-        api_->compute.pipe_refresh();
-    }
-}
-
-void TransformApi::set_y_accu_level(uint y_value) const
-{
     SET_SETTING(Y, width, y_value);
+    check_y_limits();
+
     api_->compute.pipe_refresh();
+
+    return ApiCode::OK;
 }
 
-void TransformApi::set_y_cuts(uint value) const
+ApiCode TransformApi::set_y_cuts(uint value) const
 {
-    if (value < api_->input.get_input_fd().height)
-    {
-        SET_SETTING(Y, start, value);
-        api_->compute.pipe_refresh();
-    }
+    NOT_SAME_AND_NOT_RAW(get_y_cuts(), value);
+
+    SET_SETTING(Y, start, value);
+    check_y_limits();
+
+    api_->compute.pipe_refresh();
+
+    return ApiCode::OK;
 }
 
 #pragma endregion

--- a/Holovibes/sources/api/transform_api.cc
+++ b/Holovibes/sources/api/transform_api.cc
@@ -2,6 +2,12 @@
 
 #include "API.hh"
 
+#define NOT_SAME_AND_NOT_RAW(old_val, new_val)                                                                         \
+    if (old_val == new_val)                                                                                            \
+        return ApiCode::NO_CHANGE;                                                                                     \
+    if (api_->compute.get_compute_mode() == Computation::Raw)                                                          \
+        return ApiCode::WRONG_COMP_MODE;
+
 namespace holovibes::api
 {
 
@@ -82,11 +88,7 @@ ApiCode TransformApi::set_time_stride(uint time_stride) const
 
 ApiCode TransformApi::set_space_transformation(const SpaceTransformation value) const
 {
-    if (get_space_transformation() == value)
-        return ApiCode::NO_CHANGE;
-
-    if (api_->compute.get_compute_mode() == Computation::Raw)
-        return ApiCode::WRONG_COMP_MODE;
+    NOT_SAME_AND_NOT_RAW(get_space_transformation(), value);
 
     UPDATE_SETTING(SpaceTransformation, value);
     api_->compute.pipe_refresh();
@@ -96,11 +98,7 @@ ApiCode TransformApi::set_space_transformation(const SpaceTransformation value) 
 
 ApiCode TransformApi::set_lambda(float value) const
 {
-    if (get_lambda() == value)
-        return ApiCode::NO_CHANGE;
-
-    if (api_->compute.get_compute_mode() == Computation::Raw)
-        return ApiCode::WRONG_COMP_MODE;
+    NOT_SAME_AND_NOT_RAW(get_lambda(), value);
 
     if (value < 0)
     {
@@ -116,11 +114,7 @@ ApiCode TransformApi::set_lambda(float value) const
 
 ApiCode TransformApi::set_z_distance(float value) const
 {
-    if (get_z_distance() == value)
-        return ApiCode::NO_CHANGE;
-
-    if (api_->compute.get_compute_mode() == Computation::Raw)
-        return ApiCode::WRONG_COMP_MODE;
+    NOT_SAME_AND_NOT_RAW(get_z_distance(), value);
 
     // Avoid 0 for cuda kernel
     if (value == 0)
@@ -138,11 +132,7 @@ ApiCode TransformApi::set_z_distance(float value) const
 
 ApiCode TransformApi::set_time_transformation_size(uint time_transformation_size) const
 {
-    if (get_time_transformation_size() == time_transformation_size)
-        return ApiCode::NO_CHANGE;
-
-    if (api_->compute.get_compute_mode() == Computation::Raw)
-        return ApiCode::WRONG_COMP_MODE;
+    NOT_SAME_AND_NOT_RAW(get_time_transformation_size(), time_transformation_size);
 
     if (time_transformation_size < 1)
     {
@@ -164,11 +154,7 @@ ApiCode TransformApi::set_time_transformation_size(uint time_transformation_size
 
 ApiCode TransformApi::set_time_transformation(const TimeTransformation value) const
 {
-    if (get_time_transformation() == value)
-        return ApiCode::NO_CHANGE;
-
-    if (api_->compute.get_compute_mode() == Computation::Raw)
-        return ApiCode::WRONG_COMP_MODE;
+    NOT_SAME_AND_NOT_RAW(get_time_transformation(), value);
 
     UPDATE_SETTING(TimeTransformation, value);
     api_->composite.set_z_fft_shift(value == TimeTransformation::STFT);

--- a/Holovibes/sources/api/transform_api.cc
+++ b/Holovibes/sources/api/transform_api.cc
@@ -36,10 +36,8 @@ ApiCode TransformApi::set_batch_size(uint batch_size) const
     // Adjust value of time stride if needed
     set_time_stride(get_time_stride());
 
-    if (api_->compute.get_is_computation_stopped())
-        return ApiCode::OK;
-
-    api_->compute.get_compute_pipe()->request(ICS::UpdateBatchSize);
+    if (!api_->compute.get_is_computation_stopped())
+        api_->compute.get_compute_pipe()->request(ICS::UpdateBatchSize);
 
     return ApiCode::OK;
 }
@@ -74,10 +72,8 @@ ApiCode TransformApi::set_time_stride(uint time_stride) const
 
     UPDATE_SETTING(TimeStride, time_stride);
 
-    if (api_->compute.get_is_computation_stopped())
-        return ApiCode::OK;
-
-    api_->compute.get_compute_pipe()->request(ICS::UpdateTimeStride);
+    if (!api_->compute.get_is_computation_stopped())
+        api_->compute.get_compute_pipe()->request(ICS::UpdateTimeStride);
 
     return ApiCode::OK;
 }
@@ -179,7 +175,7 @@ void TransformApi::check_p_limits() const
 
     if (std::cmp_greater(get_p_accu_level(), upper_bound))
     {
-        LOG_WARN("z width is greater than the time window, setting it: {}", upper_bound);
+        LOG_WARN("p width is greater than the time window, setting it: {}", upper_bound);
         set_p_accu_level(upper_bound);
     }
 
@@ -187,7 +183,7 @@ void TransformApi::check_p_limits() const
 
     if (get_p_index() > static_cast<uint>(upper_bound))
     {
-        LOG_WARN("z start + z width is greater than the time window, setting z start to: {}", upper_bound);
+        LOG_WARN("p start + p width is greater than the time window, setting z start to: {}", upper_bound);
         set_p_index(upper_bound);
     }
 }
@@ -222,7 +218,7 @@ void TransformApi::check_q_limits() const
 
     if (std::cmp_greater(get_q_accu_level(), upper_bound))
     {
-        LOG_WARN("z2 width is greater than the time window, setting it: {}", upper_bound);
+        LOG_WARN("q width is greater than the time window, setting it: {}", upper_bound);
         set_q_accu_level(upper_bound);
     }
 
@@ -230,7 +226,7 @@ void TransformApi::check_q_limits() const
 
     if (get_q_index() > static_cast<uint>(upper_bound))
     {
-        LOG_WARN("z2 start + z2 width is greater than the time window, setting z2 start to: {}", upper_bound);
+        LOG_WARN("q start + q width is greater than the time window, setting z2 start to: {}", upper_bound);
         set_q_index(upper_bound);
     }
 }

--- a/Holovibes/sources/core/pipe.cc
+++ b/Holovibes/sources/core/pipe.cc
@@ -41,8 +41,10 @@ bool Pipe::can_insert_to_record_queue(int nb_elm_to_add)
         return false;
     }
 
-    if (!unlimited_record &&
-        nb_frames_acquired_ >= (total_nb_frames_to_acquire_ + setting<settings::RecordFrameOffset>()))
+    size_t total =
+        total_nb_frames_to_acquire_ * (setting<settings::FrameSkip>() + 1) + setting<settings::RecordFrameOffset>();
+
+    if (!unlimited_record && nb_frames_acquired_ >= total)
     {
         API.record.set_frame_acquisition_enabled(false);
         return false;

--- a/Holovibes/sources/gui/windows/MainWindow.cc
+++ b/Holovibes/sources/gui/windows/MainWindow.cc
@@ -579,7 +579,11 @@ void MainWindow::change_camera(CameraKind c)
         gui::start(window_max_size);
 }
 
-void MainWindow::camera_none() { change_camera(CameraKind::NONE); }
+void MainWindow::camera_none()
+{
+    ui_->actionSettings->setEnabled(false);
+    change_camera(CameraKind::NONE);
+}
 
 void MainWindow::camera_ids() { change_camera(CameraKind::IDS); }
 
@@ -607,11 +611,6 @@ void MainWindow::camera_euresys_egrabber() { change_camera(CameraKind::Ametek); 
 
 void MainWindow::camera_alvium() { change_camera(CameraKind::Alvium); }
 
-void MainWindow::configure_camera()
-{
-    QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(api_.input.get_camera_ini_name())));
-}
-
 void open_file(const std::string& filename)
 {
     if (filename.empty())
@@ -620,6 +619,8 @@ void open_file(const std::string& filename)
     QDesktopServices::openUrl(QUrl::fromLocalFile(
         QString::fromStdString((RELATIVE_PATH(__CAMERAS_CONFIG_FOLDER_PATH__ / filename)).string())));
 }
+
+void MainWindow::configure_camera() { open_file(api_.input.get_camera_ini_name()); }
 
 void MainWindow::camera_ids_settings() { open_file("ids.ini"); }
 

--- a/Holovibes/sources/gui/windows/panels/image_rendering_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/image_rendering_panel.cc
@@ -160,14 +160,14 @@ void ImageRenderingPanel::set_compute_mode(int mode)
 
 void ImageRenderingPanel::update_batch_size()
 {
-    api_.transform.update_batch_size(ui_->BatchSizeSpinBox->value());
-    parent_->notify();
+    if (api_.transform.set_batch_size(ui_->BatchSizeSpinBox->value()) == ApiCode::OK)
+        parent_->notify();
 }
 
 void ImageRenderingPanel::update_time_stride()
 {
-    api_.transform.update_time_stride(ui_->TimeStrideSpinBox->value());
-    parent_->notify();
+    if (api_.transform.set_time_stride(ui_->TimeStrideSpinBox->value()) == ApiCode::OK)
+        parent_->notify();
 }
 
 void ImageRenderingPanel::set_filter2d(bool checked)
@@ -232,8 +232,8 @@ void ImageRenderingPanel::set_space_transformation(const QString& value)
         throw;
     }
 
-    api_.transform.set_space_transformation(st);
-    parent_->notify();
+    if (api_.transform.set_space_transformation(st) == ApiCode::OK)
+        parent_->notify();
 }
 
 void ImageRenderingPanel::set_time_transformation(const QString& value)
@@ -254,8 +254,8 @@ void ImageRenderingPanel::set_time_transformation_size()
 // λ
 void ImageRenderingPanel::set_lambda(const double value)
 {
-    api_.transform.set_lambda(static_cast<float>(value) * 1.0e-9f);
-    ui_->BoundaryDoubleSpinBox->setValue(api_.information.get_boundary() * 1000);
+    if (api_.transform.set_lambda(static_cast<float>(value) * 1.0e-9f) == ApiCode::OK)
+        ui_->BoundaryDoubleSpinBox->setValue(api_.information.get_boundary() * 1000);
 }
 
 void ImageRenderingPanel::set_z_distance_slider(int value)

--- a/Holovibes/sources/gui/windows/panels/image_rendering_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/image_rendering_panel.cc
@@ -241,14 +241,14 @@ void ImageRenderingPanel::set_time_transformation(const QString& value)
     // json{} return an array
     TimeTransformation tt = json{value.toStdString()}[0].get<TimeTransformation>();
 
-    api_.transform.set_time_transformation(tt);
-    parent_->notify();
+    if (api_.transform.set_time_transformation(tt) == ApiCode::OK)
+        parent_->notify();
 }
 
 void ImageRenderingPanel::set_time_transformation_size()
 {
-    api_.transform.update_time_transformation_size(ui_->timeTransformationSizeSpinBox->value());
-    parent_->notify();
+    if (api_.transform.set_time_transformation_size(ui_->timeTransformationSizeSpinBox->value()) == ApiCode::OK)
+        parent_->notify();
 }
 
 // λ

--- a/Holovibes/sources/gui/windows/panels/view_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/view_panel.cc
@@ -173,8 +173,6 @@ void ViewPanel::on_notify()
     ui_->PAccSpinBox->setVisible(is_data_not_moments);
     ui_->PAccLabel->setVisible(is_data_not_moments);
 
-    api_.transform.check_p_limits(); // FIXME: May be moved in setters
-
     // Enforce maximum value for p_index and p_accu_level
     ui_->PSpinBox->setMaximum(api_.transform.get_time_transformation_size() - api_.transform.get_p_accu_level() - 1);
     ui_->PAccSpinBox->setMaximum(api_.transform.get_time_transformation_size() - api_.transform.get_p_index() - 1);
@@ -196,8 +194,6 @@ void ViewPanel::on_notify()
 
     ui_->Q_AccSpinBox->setValue(api_.transform.get_q_accu_level());
     ui_->Q_SpinBox->setValue(api_.transform.get_q_index());
-
-    api_.transform.check_q_limits(); // FIXME: May be moved in setters
 
     // Enforce maximum value for p_index and p_accu_level
     ui_->Q_SpinBox->setMaximum(api_.transform.get_time_transformation_size() - api_.transform.get_q_accu_level() - 1);

--- a/Holovibes/sources/gui/windows/panels/view_panel.cc
+++ b/Holovibes/sources/gui/windows/panels/view_panel.cc
@@ -211,7 +211,10 @@ void ViewPanel::on_notify()
         max_height = api_.input.get_input_fd().height - 1;
     }
     else
-        api_.transform.set_x_y(0, 0);
+    {
+        api_.transform.set_x_cuts(0);
+        api_.transform.set_y_cuts(0);
+    }
 
     ui_->XSpinBox->setMaximum(max_width);
     ui_->YSpinBox->setMaximum(max_height);
@@ -309,7 +312,8 @@ void ViewPanel::update_raw_view(bool checked)
 
 void ViewPanel::set_x_y()
 {
-    api_.transform.set_x_y(ui_->XSpinBox->value(), ui_->YSpinBox->value());
+    api_.transform.set_x_cuts(ui_->XSpinBox->value());
+    api_.transform.set_y_cuts(ui_->YSpinBox->value());
     parent_->notify();
 }
 


### PR DESCRIPTION
Some little bugs fix:
- record with frame skip is handled correctly
- when no camera is loaded we cannot open the ini file of the current camera
- delete the log_error of debug when the convolution was requested

Transform api is now more secure:
- Each setter returns an ApiCode enum
- Add checks for raw mode and if value changed for each setter
- Bounds check are done properly
- When a setting is not in the right bound and is updated a log_warn is emitted to notify the user.