### PR TITLE
Re-added benchmark mode in CLI

### DIFF
--- a/Holovibes/includes/cli/options_parser.hh
+++ b/Holovibes/includes/cli/options_parser.hh
@@ -35,6 +35,7 @@ struct OptionsDescriptor
     std::optional<unsigned int> frame_skip;
     std::optional<unsigned int> mp4_fps;
     bool moments_record;
+    bool benchmark;
 };
 
 /*! \class OptionsParser

--- a/Holovibes/sources/cli/cli.cc
+++ b/Holovibes/sources/cli/cli.cc
@@ -157,6 +157,8 @@ static int set_parameters(const holovibes::OptionsDescriptor& opts)
         api.record.set_record_mode(holovibes::RecordMode::HOLOGRAM);
     }
 
+    api.information.set_benchmark_mode(opts.benchmark);
+
     if (int ret = get_first_and_last_frame(opts, static_cast<uint>(input_frame_file->get_total_nb_frames())))
         return ret; // error 31, 32
 

--- a/Holovibes/sources/cli/options_parser.cc
+++ b/Holovibes/sources/cli/options_parser.cc
@@ -189,6 +189,7 @@ OptionsDescriptor OptionsParser::parse(int argc, char* const argv[])
             }
         }
         options_.moments_record = vm_["moments_record"].as<bool>();
+        options_.benchmark = vm_["benchmark"].as<bool>();
     }
     catch (std::exception& e)
     {

--- a/Holovibes/sources/cli/options_parser.cc
+++ b/Holovibes/sources/cli/options_parser.cc
@@ -90,6 +90,11 @@ OptionsParser::OptionsParser()
         po::bool_switch()->default_value(false),
         "Record moments (default = false)"
     )
+    (
+        "benchmark,b",
+        po::bool_switch()->default_value(false),
+        "Benchmark: record application data into a file at runtime (default = false)"
+    )
     ;
     // clang-format on
 

--- a/Holovibes/sources/thread/benchmark_worker.cc
+++ b/Holovibes/sources/thread/benchmark_worker.cc
@@ -37,7 +37,10 @@ void BenchmarkWorker::run()
     std::string benchmark_file_path = settings::benchmark_dirpath + "/benchmark_NOW.csv";
     benchmark_file.open(benchmark_file_path);
     if (!benchmark_file.is_open())
+    {
         LOG_ERROR("Could not open benchmark file at " + benchmark_file_path + ", you may need to create the folder");
+        return;
+    }
 
     while (!stop_requested_)
     {
@@ -56,10 +59,13 @@ void BenchmarkWorker::run()
                 if (information_.output_format)
                     benchmark_file << ",Output Format: " << *information_.output_format.get();
 
-                for (auto const& [key, info] :
-                     information_.queues) //! FIXME causes a crash on start when camera pre-selected
+                for (auto [key, info] : information_.queues)
+                {
+                    if (key == QueueType::UNDEFINED)
+                        continue;
                     benchmark_file << "," << (info.device == Device::GPU ? "GPU " : "CPU ")
                                    << queue_type_to_string_.at(key) << " size: " << info.max_size;
+                }
                 benchmark_file << "\n";
                 // 11 headers
                 benchmark_file << "Input Queue,Output Queue,Record Queue,Input FPS,Output FPS,Input Throughput,Output "


### PR DESCRIPTION
The benchmark mode is available again in the CLI, under the -b [--benchmark] option.

It is disabled by default.